### PR TITLE
add camera

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.31)
 
-project(DirkEngine VERSION 1.0.0 LANGUAGES C CXX)
+project(DirkEngine VERSION 0.1.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/engine/dirkengine.hpp
+++ b/include/engine/dirkengine.hpp
@@ -9,6 +9,7 @@
 
 #include "actor.hpp"
 #include "core/globals.hpp"
+#include "render/camera.hpp"
 #include "render/render_types.hpp"
 #include "render/renderer.hpp"
 #include "render/vulkan_types.hpp"
@@ -45,6 +46,14 @@ public:
 
 private:
     std::unordered_map<std::string_view, std::shared_ptr<Actor>> actors;
+    // END
+
+    // TODO: move this to player manager class
+public:
+    Camera* getCamera() { return camera.get(); }
+
+private:
+    std::unique_ptr<Camera> camera;
     // END
 
 private:

--- a/include/render/camera.hpp
+++ b/include/render/camera.hpp
@@ -35,8 +35,8 @@ private:
     // camera settings
     float fieldOfView = glm::radians(90.f);
     float aspectRatio = 16.f / 9.f;
-    float near = .0001;
-    float far = 1000.f;
+    float near = .1;
+    float far = 100000.f;
 };
 
 } // namespace dirk

--- a/include/render/camera.hpp
+++ b/include/render/camera.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "core/globals.hpp"
+
+#include "glm/glm.hpp"
+
+namespace dirk {
+
+DECLARE_LOG_CATEGORY_EXTERN(LogCamera)
+
+class Camera {
+public:
+    Camera();
+
+    void tick(float deltaTime);
+
+    inline const glm::mat4 getProjectionMatrix() const noexcept { return projectionMatrix; }
+
+    inline float getFieldOfView() { return fieldOfView; }
+    void setFieldOfView(float inFieldOfView);
+
+    inline float getAspectRatio() { return aspectRatio; }
+    void setAspectRatio(float inAspectRatio);
+
+    inline float getNear() { return near; }
+    void setNear(float inNear);
+
+    inline float getFar() { return far; }
+    void setFar(float inFar);
+
+private:
+    void updateProjectionMatrix();
+    glm::mat4 projectionMatrix{ 1.f };
+
+    // camera settings
+    float fieldOfView = glm::radians(90.f);
+    float aspectRatio = 16.f / 9.f;
+    float near = .0001;
+    float far = 1000.f;
+};
+
+} // namespace dirk

--- a/include/render/renderer.hpp
+++ b/include/render/renderer.hpp
@@ -157,7 +157,7 @@ private:
 
     const std::vector<const char*> deviceExtensions = { vk::KHRSwapchainExtensionName };
     const int MAX_FRAMES_IN_FLIGHT = 2; // dont make this too high or CPU will go faster than GPU, causing latency
-    const int MAX_DESCRIPTOR_SET_COUNT = 20;
+    const int MAX_DESCRIPTOR_SET_COUNT = 20; // incrementally increase as scenes get bigger
     vk::SampleCountFlagBits msaaSamples = vk::SampleCountFlagBits::e1;
 
     RendererProperties properties;

--- a/include/render/renderer.hpp
+++ b/include/render/renderer.hpp
@@ -157,6 +157,7 @@ private:
 
     const std::vector<const char*> deviceExtensions = { vk::KHRSwapchainExtensionName };
     const int MAX_FRAMES_IN_FLIGHT = 2; // dont make this too high or CPU will go faster than GPU, causing latency
+    const int MAX_DESCRIPTOR_SET_COUNT = 20;
     vk::SampleCountFlagBits msaaSamples = vk::SampleCountFlagBits::e1;
 
     RendererProperties properties;

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -26,8 +26,17 @@ dirk::DirkEngineCreateInfo dirk::getEngineCreateInfo(int argc, char** argv) {
                 .modelName = "Duck",
                 .transform = Transform{
                     .location = glm::vec3(-100.f, 0.f, 0.f),
-                    .rotation = glm::vec3(0.f),
+                    .rotation = glm::vec3(-90.f, 0.f, 0.f),
                     .scale = glm::vec3(1.f),
+                },
+            },
+            ActorCreateInfo{
+                .name = "Viking Room",
+                .modelName = "viking_room",
+                .transform = Transform{
+                    .location = glm::vec3(0.f, -200.f, -200.f),
+                    .rotation = glm::vec3(-135.f, 0.f, 0.f),
+                    .scale = glm::vec3(600.f),
                 },
             },
         },

--- a/src/engine/actor.cpp
+++ b/src/engine/actor.cpp
@@ -189,7 +189,7 @@ void Actor::updateData() {
 void Actor::recordCommandBuffer(vk::CommandBuffer commandBuffer, vk::PipelineLayout pipelineLayout) {
     ModelViewProjection mvp{
         .model = getTransformMatrix(),
-        .view = glm::lookAt(glm::vec3(0.f, 200.f, 200.f), glm::vec3(0.f, 0.f, 0.f), glm::vec3(0.f, 0.f, 1.f)), // TDOO: get from player location in the future
+        .view = glm::lookAt(glm::vec3(0.f, 400.f, 400.f), glm::vec3(0.f, 0.f, 0.f), glm::vec3(0.f, 0.f, 1.f)), // TDOO: get from player location in the future
         .proj = engine->getCamera()->getProjectionMatrix(),
     };
     std::memcpy(uniformBufferMapped, &mvp, sizeof(mvp));

--- a/src/engine/actor.cpp
+++ b/src/engine/actor.cpp
@@ -188,9 +188,9 @@ void Actor::updateData() {
 
 void Actor::recordCommandBuffer(vk::CommandBuffer commandBuffer, vk::PipelineLayout pipelineLayout) {
     ModelViewProjection mvp{
-        .model = transformMatrix,
+        .model = getTransformMatrix(),
         .view = glm::lookAt(glm::vec3(0.f, 200.f, 200.f), glm::vec3(0.f, 0.f, 0.f), glm::vec3(0.f, 0.f, 1.f)), // TDOO: get from player location in the future
-        .proj = engine->getRenderer()->getProjection(),
+        .proj = engine->getCamera()->getProjectionMatrix(),
     };
     std::memcpy(uniformBufferMapped, &mvp, sizeof(mvp));
 

--- a/src/engine/dirkengine.cpp
+++ b/src/engine/dirkengine.cpp
@@ -1,5 +1,6 @@
 #include "engine/dirkengine.hpp"
 #include "core/globals.hpp"
+#include "render/camera.hpp"
 #include "render/renderer.hpp"
 #include "resources/resource_manager.hpp"
 
@@ -25,6 +26,8 @@ DirkEngine::DirkEngine(DirkEngineCreateInfo& createInfo) {
     check(renderer);
 
     init();
+
+    camera = std::make_unique<Camera>();
 
     for (auto actorCreateInfo : createInfo.actorCreateInfos) {
         spawnActor(actorCreateInfo);
@@ -80,6 +83,7 @@ int DirkEngine::init() {
 }
 
 void DirkEngine::tick(float deltaTime) {
+    camera->tick(deltaTime);
     for (auto pair : actors) {
         pair.second->tick(deltaTime);
     }

--- a/src/render/camera.cpp
+++ b/src/render/camera.cpp
@@ -1,0 +1,35 @@
+#include "render/camera.hpp"
+
+#include "glm/gtc/matrix_transform.hpp"
+
+namespace dirk {
+
+DEFINE_LOG_CATEGORY(LogCamera);
+
+Camera::Camera() { updateProjectionMatrix(); }
+
+void Camera::tick(float deltaTime) {}
+
+void Camera::setFieldOfView(float inFieldOfView) {
+    fieldOfView = inFieldOfView;
+    updateProjectionMatrix();
+}
+void Camera::setAspectRatio(float inAspectRation) {
+    aspectRatio = inAspectRation;
+    updateProjectionMatrix();
+}
+void Camera::setNear(float inNear) {
+    near = inNear;
+    updateProjectionMatrix();
+}
+void Camera::setFar(float inFar) {
+    far = inFar;
+    updateProjectionMatrix();
+}
+
+void Camera::updateProjectionMatrix() {
+    projectionMatrix = glm::perspective(fieldOfView, aspectRatio, near, far);
+    // projectionMatrix[1][1] *= -1;
+}
+
+} // namespace dirk

--- a/src/render/camera.cpp
+++ b/src/render/camera.cpp
@@ -29,7 +29,6 @@ void Camera::setFar(float inFar) {
 
 void Camera::updateProjectionMatrix() {
     projectionMatrix = glm::perspective(fieldOfView, aspectRatio, near, far);
-    // projectionMatrix[1][1] *= -1;
 }
 
 } // namespace dirk

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -2,6 +2,7 @@
 #include "core/asserts.hpp"
 #include "core/globals.hpp"
 #include "engine/dirkengine.hpp"
+#include "render/camera.hpp"
 #include "render/render_utils.hpp"
 #include "render/vulkan_types.hpp"
 
@@ -142,11 +143,9 @@ void Renderer::draw(float deltaTime) {
         return;
     }
 
-    for (uint32_t i = 0; i < UINT32_MAX / 16; i++) {
+    for (uint32_t i = 0; i < UINT32_MAX / 512; i++) {
         deltaTime = deltaTime + 0;
     }
-
-    DIRK_LOG(LogVulkan, TRACE, "draw");
 
     drawFrame();
 }
@@ -496,6 +495,8 @@ void Renderer::recreateSwapChain() {
 
     std::vector<vk::Image> swapChainImages = createSwapChain(this->swapChain);
     this->swapChainImages = createSwapChainImages(swapChainImages);
+
+    getEngine()->getCamera()->setAspectRatio(static_cast<float>(swapChainExtent.width) / static_cast<float>(swapChainExtent.height));
 }
 
 vk::RenderPass Renderer::createRenderPass() {
@@ -1056,12 +1057,6 @@ void Renderer::drawFrame() {
 
     currentFrame = (++currentFrame) % MAX_FRAMES_IN_FLIGHT;
     currentSemaphore = (++currentSemaphore) % semaphores.size();
-}
-
-glm::mat4 Renderer::getProjection() {
-    glm::mat4 proj = glm::perspective(glm::radians(90.f), static_cast<float>(swapChainExtent.width) / static_cast<float>(swapChainExtent.height), .0001f, 10000.f);
-    proj[1][1] *= -1;
-    return proj;
 }
 
 } // namespace dirk

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -593,12 +593,12 @@ vk::DescriptorSetLayout Renderer::createDescriptorSetLayout() {
 
 vk::DescriptorPool Renderer::createDescriptorPool() {
     std::array poolSizes{
-        vk::DescriptorPoolSize(vk::DescriptorType::eUniformBuffer, MAX_FRAMES_IN_FLIGHT),
-        vk::DescriptorPoolSize(vk::DescriptorType::eCombinedImageSampler, MAX_FRAMES_IN_FLIGHT),
+        vk::DescriptorPoolSize(vk::DescriptorType::eUniformBuffer, MAX_DESCRIPTOR_SET_COUNT),
+        vk::DescriptorPoolSize(vk::DescriptorType::eCombinedImageSampler, MAX_DESCRIPTOR_SET_COUNT),
     };
     vk::DescriptorPoolCreateInfo poolInfo{};
     poolInfo.flags = vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet;
-    poolInfo.maxSets = MAX_FRAMES_IN_FLIGHT;
+    poolInfo.maxSets = MAX_DESCRIPTOR_SET_COUNT;
     poolInfo.poolSizeCount = poolSizes.size();
     poolInfo.pPoolSizes = poolSizes.data();
 

--- a/src/resources/resource_manager.cpp
+++ b/src/resources/resource_manager.cpp
@@ -83,11 +83,7 @@ std::shared_ptr<const Model> ResourceManager::loadModel(const std::string& name)
         }
 
         vertex.color = { 1.f, 1.f, 1.f };
-
-        if (!uniqueVertices.contains(vertex)) {
-            uniqueVertices[vertex] = vertices.size();
-            vertices.push_back(vertex);
-        }
+        vertices.push_back(vertex);
     }
 
     // indices
@@ -99,21 +95,21 @@ std::shared_ptr<const Model> ResourceManager::loadModel(const std::string& name)
     case TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE: {
         const uint8_t* indexData = reinterpret_cast<const uint8_t*>(&indexBuffer.data[indexBufferView.byteOffset + indexAccessor.byteOffset]);
         for (size_t i = 0; i < indexAccessor.count; i++) {
-            indices.push_back(uniqueVertices[vertices[indexData[i]]]);
+            indices.push_back(indexData[i]);
         }
         break;
     }
     case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT: {
         const uint16_t* indexData = reinterpret_cast<const uint16_t*>(&indexBuffer.data[indexBufferView.byteOffset + indexAccessor.byteOffset]);
         for (size_t i = 0; i < indexAccessor.count; i++) {
-            indices.push_back(uniqueVertices[vertices[indexData[i]]]);
+            indices.push_back(indexData[i]);
         }
         break;
     }
     case TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT: {
         const uint32_t* indexData = reinterpret_cast<const uint32_t*>(&indexBuffer.data[indexBufferView.byteOffset + indexAccessor.byteOffset]);
         for (size_t i = 0; i < indexAccessor.count; i++) {
-            indices.push_back(uniqueVertices[vertices[indexData[i]]]);
+            indices.push_back(indexData[i]);
         }
         break;
     }


### PR DESCRIPTION
Closes #42 
Closes #36 

Changes:

- Add `Camera` class with all the settings. It provides the projection matrix to the actors
- Created and managed by the engine class
- Create a variable to control the max descriptor set count. Incrementally increase as scenes get biffer
- Add `viking_room` and move stuff around to have nicer scene
- Fix issue with indices when loading from gltf
- Changed version from `1.0.0` to `0.1.0`