### PR TITLE
Genrate Compile Commands with DirkBuild Tool

### DIFF
--- a/Engine/Programs/DirkBuildTool/Source/build/build.go
+++ b/Engine/Programs/DirkBuildTool/Source/build/build.go
@@ -52,7 +52,9 @@ func Build(buildConfig *setup.BuildConfig) error {
 			return err
 		}
 
-		output.WriteIntFile("compile_commands.json", data, true)
+		if err := output.WriteIntFile("compile_commands.json", data, true); err != nil {
+			return err
+		}
 	}
 
 	if err := module.Build(target); err == nil {

--- a/Engine/Programs/DirkBuildTool/Source/build/build.go
+++ b/Engine/Programs/DirkBuildTool/Source/build/build.go
@@ -37,7 +37,9 @@ func Build(buildConfig *setup.BuildConfig) error {
 
 	if cppTarget, ok := target.(*module.CppModule); ok {
 		log.Printf("Resolving dependencies\n")
-		cppTarget.ResolveDependencies(modules, nil)
+		if err := cppTarget.ResolveDependencies(modules, nil); err != nil {
+			return err
+		}
 	}
 
 	if err := module.Build(target); err == nil {

--- a/Engine/Programs/DirkBuildTool/Source/build/build.go
+++ b/Engine/Programs/DirkBuildTool/Source/build/build.go
@@ -3,6 +3,7 @@ package build
 import (
 	"DirkBuildTool/config"
 	"DirkBuildTool/module"
+	"DirkBuildTool/output"
 	"DirkBuildTool/setup"
 	"encoding/json"
 	"fmt"
@@ -40,6 +41,18 @@ func Build(buildConfig *setup.BuildConfig) error {
 		if err := cppTarget.ResolveDependencies(modules, nil); err != nil {
 			return err
 		}
+
+		compileCommands, err := cppTarget.GenerateCompileCommands()
+		if err != nil {
+			return err
+		}
+
+		data, err := json.Marshal(compileCommands)
+		if err != nil {
+			return err
+		}
+
+		output.WriteIntFile("compile_commands.json", data, true)
 	}
 
 	if err := module.Build(target); err == nil {

--- a/Engine/Programs/DirkBuildTool/Source/make/makefile.go
+++ b/Engine/Programs/DirkBuildTool/Source/make/makefile.go
@@ -84,7 +84,11 @@ func (m *CppMakefile) ToBytes() ([]byte, error) {
 
 	defines := []string{}
 	for key, value := range m.Defines {
-		defines = append(defines, fmt.Sprintf("-D%s=\\\"%s\\\"", key, value))
+		if value == "" {
+			defines = append(defines, fmt.Sprintf("-D%s", key))
+		} else {
+			defines = append(defines, fmt.Sprintf("-D%s=\\\"%s\\\"", key, value))
+		}
 	}
 	writeVar(buffer, "DEFINES", defines...)
 

--- a/Engine/Programs/DirkBuildTool/Source/make/makefile.go
+++ b/Engine/Programs/DirkBuildTool/Source/make/makefile.go
@@ -42,7 +42,8 @@ type CppMakefile struct {
 	Name, Target       string
 	BuildType, RootDir string
 	IncDirs            []string
-	Libs, Defines      []string
+	Libs               []string
+	Defines            map[string]string
 	LdFlags, CFlags    string
 	IsLib, IsStatic    bool
 	Optimize           bool
@@ -82,8 +83,8 @@ func (m *CppMakefile) ToBytes() ([]byte, error) {
 	writeVar(buffer, "CXXFLAGS", cxxFlags...)
 
 	defines := []string{}
-	for _, define := range m.Defines {
-		defines = append(defines, fmt.Sprintf("-D%s", define))
+	for key, value := range m.Defines {
+		defines = append(defines, fmt.Sprintf("-D%s=\\\"%s\\\"", key, value))
 	}
 	writeVar(buffer, "DEFINES", defines...)
 

--- a/Engine/Programs/DirkBuildTool/Source/models/models.go
+++ b/Engine/Programs/DirkBuildTool/Source/models/models.go
@@ -1,8 +1,9 @@
 package models
 
 type Dependency struct {
-	Name         string   `json:"name"`
-	IsHeaderOnly bool     `json:"header_only"`
-	IncludeDir   string   `json:"inc_dir"`
-	Defines      []string `json:"defines,omitempty"`
+	Name         string            `json:"name"`
+	IsHeaderOnly bool              `json:"header_only"`
+	IncludeDir   string            `json:"inc_dir"`
+	Defines      map[string]string `json:"defines,omitempty"`
+}
 }

--- a/Engine/Programs/DirkBuildTool/Source/models/models.go
+++ b/Engine/Programs/DirkBuildTool/Source/models/models.go
@@ -6,4 +6,12 @@ type Dependency struct {
 	IncludeDir   string            `json:"inc_dir"`
 	Defines      map[string]string `json:"defines,omitempty"`
 }
+
+type CompileCommands []*CompileCommand
+
+type CompileCommand struct {
+	Directory string   `json:"directory"`
+	Arguments []string `json:"arguments"`
+	File      string   `json:"file"`
+	Output    string   `json:"output"`
 }

--- a/Engine/Programs/DirkBuildTool/Source/module/cpp.go
+++ b/Engine/Programs/DirkBuildTool/Source/module/cpp.go
@@ -7,6 +7,7 @@ import (
 	"DirkBuildTool/setup"
 	"fmt"
 	"log"
+	"maps"
 	"slices"
 )
 
@@ -36,9 +37,7 @@ func (m *CppModule) ToMakefile() make.Makefile {
 			incDirs = append(incDirs, dep.IncludeDir)
 		}
 
-		for key, value := range dep.Defines {
-			defines[key] = value
-		}
+		maps.Copy(defines, dep.Defines)
 
 		if dep.IsHeaderOnly {
 			continue
@@ -48,9 +47,7 @@ func (m *CppModule) ToMakefile() make.Makefile {
 	}
 
 	for _, dep := range m.Dependants {
-		for key, value := range dep.Defines {
-			defines[key] = value
-		}
+		maps.Copy(defines, dep.Defines)
 	}
 
 	warningFlags := "" // "-Wall -Wextra"

--- a/Engine/Programs/DirkBuildTool/Source/module/cpp.go
+++ b/Engine/Programs/DirkBuildTool/Source/module/cpp.go
@@ -114,10 +114,9 @@ func (m *CppModule) getDeps() []*models.Dependency {
 	return deps
 }
 
-func (m *CppModule) ResolveDependencies(modules map[string]Module, dependants []*models.Dependency) {
+func (m *CppModule) ResolveDependencies(modules map[string]Module, dependants []*models.Dependency) error {
 	if slices.Contains(dependants, m.toDep()) {
-		fmt.Printf("Circular dependency detected. Module %s has already been included\n", m.Name)
-		return
+		return fmt.Errorf("Circular dependency detected. Module %s has already been included\n", m.Name)
 	}
 
 	m.Dependants = dependants
@@ -142,4 +141,6 @@ func (m *CppModule) ResolveDependencies(modules map[string]Module, dependants []
 		}
 		m.Ext = append(m.Ext, dep)
 	}
+
+	return nil
 }

--- a/Engine/Programs/DirkBuildTool/Source/module/cpp.go
+++ b/Engine/Programs/DirkBuildTool/Source/module/cpp.go
@@ -36,8 +36,8 @@ func (m *CppModule) ToMakefile() make.Makefile {
 			incDirs = append(incDirs, dep.IncludeDir)
 		}
 
-		if defines != nil {
-			defines = append(defines, dep.Defines...)
+		for key, value := range dep.Defines {
+			defines[key] = value
 		}
 
 		if dep.IsHeaderOnly {
@@ -48,8 +48,8 @@ func (m *CppModule) ToMakefile() make.Makefile {
 	}
 
 	for _, dep := range m.Dependants {
-		if dep.Defines != nil {
-			defines = append(defines, dep.Defines...)
+		for key, value := range dep.Defines {
+			defines[key] = value
 		}
 	}
 

--- a/Engine/Programs/DirkBuildTool/Source/module/cpp.go
+++ b/Engine/Programs/DirkBuildTool/Source/module/cpp.go
@@ -6,9 +6,12 @@ import (
 	"DirkBuildTool/models"
 	"DirkBuildTool/setup"
 	"fmt"
+	"io/fs"
 	"log"
 	"maps"
+	"path/filepath"
 	"slices"
+	"strings"
 )
 
 // constructed for building
@@ -24,6 +27,77 @@ type CppModule struct {
 	Config     *ModuleConfig
 	selfDep    *models.Dependency // itself represented as a dependency
 	build      *setup.BuildConfig
+}
+
+func (m *CppModule) GenerateCompileCommands() (models.CompileCommands, error) {
+	compileCommands := models.CompileCommands{}
+
+	if err := filepath.WalkDir(fmt.Sprintf("%s/src", m.Path), func(path string, d fs.DirEntry, err error) error {
+		if d.IsDir() {
+			return nil
+		}
+
+		in := strings.Replace(path, m.Path, "", 1)
+		in = strings.Trim(in, "/")
+
+		intDir, _ := intDir(m)
+		out := fmt.Sprintf("%s/%s/%s", intDir, m.build.Type.Name, in)
+		out = strings.Replace(out, "/src/", "/obj/", 1)
+		out = strings.Replace(out, ".cpp", ".o", 1)
+
+		incDirs := []string{"include"}
+		defines := m.Config.Defines
+		for _, dep := range m.getDeps() {
+			if dep.IncludeDir != "" {
+				incDirs = append(incDirs, dep.IncludeDir)
+			}
+
+			maps.Copy(defines, dep.Defines)
+		}
+
+		for _, dep := range m.Dependants {
+			maps.Copy(defines, dep.Defines)
+		}
+
+		command := []string{"g++", "-fPIC", fmt.Sprintf("-std=%s", m.Std)}
+
+		for _, dir := range incDirs {
+			command = append(command, fmt.Sprintf("-I%s", dir))
+		}
+
+		for key, value := range defines {
+			if value == "" {
+				command = append(command, fmt.Sprintf("-D%s", key))
+			} else {
+				command = append(command, fmt.Sprintf("-D%s=\"%s\"", key, value))
+			}
+		}
+
+		command = append(command, "-c", in, "-o", out)
+
+		compileCommands = append(compileCommands, &models.CompileCommand{
+			Directory: m.Path,
+			Arguments: command,
+			File:      in,
+			Output:    out,
+		})
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	for _, dep := range m.Deps {
+		if cppModule, ok := dep.(*CppModule); ok {
+			modCommands, err := cppModule.GenerateCompileCommands()
+			if err != nil {
+				return nil, err
+			}
+			compileCommands = append(compileCommands, modCommands...)
+		}
+	}
+
+	return compileCommands, nil
 }
 
 func (m *CppModule) ToMakefile() make.Makefile {

--- a/Engine/Programs/DirkBuildTool/Source/module/module.go
+++ b/Engine/Programs/DirkBuildTool/Source/module/module.go
@@ -87,15 +87,15 @@ func intDir(m Module) (string, error) {
 
 // read from .dirkmod files
 type ModuleConfig struct {
-	Name    string   `json:"name"`
-	Target  string   `json:"target"`
-	Type    string   `json:"type"`
-	Path    string   `json:"-"`
-	Std     string   `json:"c_standard"`
-	IsLib   bool     `json:"is_lib"`
-	Deps    []string `json:"dependencies"` // project modules
-	Ext     []string `json:"external"`     // thirdparty modules
-	Defines []string `json:"defines"`
+	Name    string            `json:"name"`
+	Target  string            `json:"target"`
+	Type    string            `json:"type"`
+	Path    string            `json:"-"`
+	Std     string            `json:"c_standard"`
+	IsLib   bool              `json:"is_lib"`
+	Deps    []string          `json:"dependencies"` // project modules
+	Ext     []string          `json:"external"`     // thirdparty modules
+	Defines map[string]string `json:"defines"`
 }
 
 func (c *ModuleConfig) ToModule(buildConfig *setup.BuildConfig) Module {

--- a/Engine/Programs/DirkBuildTool/Source/setup/setup.go
+++ b/Engine/Programs/DirkBuildTool/Source/setup/setup.go
@@ -68,6 +68,8 @@ func Setup(buildConfig *BuildConfig) error {
 	Config.BuildConfig = buildConfig
 	// TODO: build glfw
 
+	os.Symlink(fmt.Sprintf("%s/compile_commands.json", config.Dirs.Intermediate), fmt.Sprintf("%s/compile_commands.json", config.Dirs.Root))
+
 	glfwDir := os.Getenv("GLFW")
 	os.Symlink(fmt.Sprintf("%s/lib/libglfw.so", glfwDir), fmt.Sprintf("%s/libglfw.so", config.Dirs.Binaries))
 	os.Symlink(fmt.Sprintf("%s/lib/libglfw.so.3", glfwDir), fmt.Sprintf("%s/libglfw.so.3", config.Dirs.Binaries))

--- a/Engine/Source/Editor/Editor.dirkmod
+++ b/Engine/Source/Editor/Editor.dirkmod
@@ -7,7 +7,7 @@
         "Runtime"
     ],
     "external": [],
-    "defines": [
-        "WITH_EDITOR"
-    ]
+    "defines": {
+        "WITH_EDITOR": ""
+    }
 }

--- a/Engine/Source/Runtime/Runtime.dirkmod
+++ b/Engine/Source/Runtime/Runtime.dirkmod
@@ -11,11 +11,11 @@
         "tinygltf",
         "vulkan"
     ],
-    "defines": [
-        "GLFW_INCLUDE_NONE",
-        "GLFW_INCLUDE_VLUKAN",
-        "LOG_PATH=\\\"Saved\\\"",
-        "RESOURCE_PATH=\\\"Engine/Assets\\\"",
-        "SHADER_PATH=\\\"Intermediate/Shaders\\\""
-    ]
+    "defines": {
+        "GLFW_INCLUDE_NONE": "",
+        "GLFW_INCLUDE_VLUKAN": "",
+        "LOG_PATH": "Saved",
+        "RESOURCE_PATH": "Engine/Assets",
+        "SHADER_PATH": "Intermediate/Shaders"
+    }
 }

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,12 @@ BUILD_TOOL_SRC=$(shell find $(BUILD_TOOL_DIR)/Source -type f -name '*')
 
 EDITOR=Binaries/DirkEditor
 
-.PHONY: clean run
-run: $(BUILD_TOOL)
-	@$(BUILD_TOOL)
+.PHONY: clean run build
+run: build
 	@$(EDITOR)
+
+build: $(BUILD_TOOL)
+	@$(BUILD_TOOL)
 
 clean:
 	@rm -rf Intermediate Saved Binaries compile_commands.json


### PR DESCRIPTION
## Summary of the PR

`DirkBuildTool` now generate a clang compilation databse.

## Issues linked to the PR: Closes #59 

## Changes

- Store defines in maps instead of just array of strings to allow for empty defines & update mod files accordingly
- Add `build` target to root makefile
- Compile commands are generated into the Int dir and sym-linked to root
