### PR TITLE
refactor: logging & assertions

### DIFF
--- a/Engine/Source/Common/include/asserts.hpp
+++ b/Engine/Source/Common/include/asserts.hpp
@@ -1,6 +1,19 @@
 #pragma once
 
-#include <cassert>
+#include "logging/logging.hpp"
 
-#define check(expr) assert(expr)
+#include <cassert>
+#include <cmath>
+#include <format>
+
+#define checkm(expr, message, ...)                                                           \
+    if (!(expr)) {                                                                           \
+        dirk::Logging::logger->log(                                                          \
+            dirk::Logging::LogCategory{ .name = "Assertion Failed" },                        \
+            dirk::Logging::FATAL,                                                            \
+            "{}:{} {}\n{}", __FILE__, __LINE__, #expr, std::format(message, ##__VA_ARGS__)); \
+    }
+
+#define check(expr) checkm(expr, "")
+
 #define checkVulkan(expr) check(expr == vk::Result::eSuccess)

--- a/Engine/Source/Common/include/common.hpp
+++ b/Engine/Source/Common/include/common.hpp
@@ -21,7 +21,6 @@
 #include "vulkan/vulkan_handles.hpp"
 #include "vulkan/vulkan_structs.hpp"
 
-#define IMGUI_IMPL_VULKAN_HAS_DYNAMIC_RENDERING
 #define IMGUI_DISABLE_OBSOLETE_FUNCTIONS
 #include "backends/imgui_impl_vulkan.h"
 #include "imgui.h"

--- a/Engine/Source/Common/include/logging/logging.hpp
+++ b/Engine/Source/Common/include/logging/logging.hpp
@@ -52,8 +52,6 @@ private:
     std::ofstream logfile;
 
     static constexpr std::string_view logPath{ LOG_PATH };
-    static constexpr std::string_view colorStart{ "\033[" };
-    static constexpr std::string_view colorEnd{ "\033[0m" };
 };
 
 static std::unique_ptr<Logger> logger = nullptr;

--- a/Engine/Source/Common/include/logging/logging.hpp
+++ b/Engine/Source/Common/include/logging/logging.hpp
@@ -1,9 +1,17 @@
 #pragma once
 
-#include <sstream>
+#include <format>
+#include <fstream>
+#include <memory>
 #include <string>
 
-namespace dirk {
+#define DECLARE_LOG_CATEGORY_EXTERN(categoryName) extern dirk::Logging::LogCategory categoryName;
+#define DEFINE_LOG_CATEGORY(categoryName) dirk::Logging::LogCategory categoryName{ .name = #categoryName };
+
+#define DIRK_LOG(category, level, message, ...) dirk::Logging::logger->log(category, dirk::Logging::level, message, ##__VA_ARGS__);
+#define DIRK_LOGM(category, level, message) dirk::Logging::logger->log(category, dirk::Logging::level, message);
+
+namespace dirk::Logging {
 
 enum LogLevel {
     FATAL,
@@ -19,33 +27,29 @@ struct LogCategory {
     bool show = true;
 };
 
-const std::string logPath{ LOG_PATH };
+void init();
+void shutdown();
 
-/**
- * will log the log category, the log level and return a stream for the rest of the message
- * this will not actually output anything
- */
-std::stringstream beginLogEntry(LogCategory category, LogLevel level);
+class Logger {
+public:
+    Logger();
+    ~Logger();
 
-/**
- * will actually output to the outputs (std::cout and/or a file)
- */
-void endLogEntry(std::stringstream stream);
+    template <typename... Args>
+    void log(LogCategory category, LogLevel level, std::format_string<Args...> fmt, Args&&... args);
+    void log(LogCategory category, LogLevel level, std::string str);
 
-/**
- * return if a message should be logged based on level and the specific category
- */
-bool shouldLog(LogCategory category, LogLevel level);
+    static bool shouldLog(LogCategory category, LogLevel level);
 
-#define DECLARE_LOG_CATEGORY_EXTERN(categoryName) extern dirk::LogCategory categoryName;
-#define DEFINE_LOG_CATEGORY(categoryName) dirk::LogCategory categoryName{ .name = #categoryName };
+private:
+    std::string filepath;
+    std::ofstream logfile;
 
-#define DIRK_LOG(category, level, messages)                                  \
-    if (dirk::shouldLog(category, level)) {                                  \
-        dirk::endLogEntry(dirk::beginLogEntry(category, level) << messages); \
-    }
+    static constexpr std::string_view logPath{ LOG_PATH };
+    static constexpr std::string_view colorStart{ "\033[" };
+    static constexpr std::string_view colorEnd{ "\033[0m" };
+};
 
-std::string getLevelString(LogLevel level);
-std::string getLevelColor(LogLevel level);
+static std::unique_ptr<Logger> logger = nullptr;
 
-} // namespace dirk
+} // namespace dirk::Logging

--- a/Engine/Source/Common/include/logging/logging.hpp
+++ b/Engine/Source/Common/include/logging/logging.hpp
@@ -9,7 +9,6 @@
 #define DEFINE_LOG_CATEGORY(categoryName) dirk::Logging::LogCategory categoryName{ .name = #categoryName };
 
 #define DIRK_LOG(category, level, message, ...) dirk::Logging::logger->log(category, dirk::Logging::level, message, ##__VA_ARGS__);
-#define DIRK_LOGM(category, level, message) dirk::Logging::logger->log(category, dirk::Logging::level, message);
 
 namespace dirk::Logging {
 

--- a/Engine/Source/Common/include/logging/logging.hpp
+++ b/Engine/Source/Common/include/logging/logging.hpp
@@ -5,9 +5,7 @@
 #include <ctime>
 #include <format>
 #include <fstream>
-#include <iostream>
 #include <memory>
-#include <ostream>
 #include <string>
 #include <string_view>
 

--- a/Engine/Source/Common/include/logging/logging.hpp
+++ b/Engine/Source/Common/include/logging/logging.hpp
@@ -33,8 +33,6 @@ struct LogCategory {
 void init();
 void shutdown();
 
-DECLARE_LOG_CATEGORY_EXTERN(Logger);
-
 class Logger {
 public:
     Logger();

--- a/Engine/Source/Common/include/logging/logging.hpp
+++ b/Engine/Source/Common/include/logging/logging.hpp
@@ -52,7 +52,8 @@ public:
 
 private:
     std::string filepath;
-    std::ofstream logfile;
+    std::ofstream latestLogfile;
+    std::ofstream archiveLogfile;
 
     static constexpr std::string_view logPath{ LOG_PATH };
 };

--- a/Engine/Source/Common/include/logging/logging.hpp
+++ b/Engine/Source/Common/include/logging/logging.hpp
@@ -1,9 +1,15 @@
 #pragma once
 
+#include <csignal>
+#include <cstdio>
+#include <ctime>
 #include <format>
 #include <fstream>
+#include <iostream>
 #include <memory>
+#include <ostream>
 #include <string>
+#include <string_view>
 
 #define DECLARE_LOG_CATEGORY_EXTERN(categoryName) extern dirk::Logging::LogCategory categoryName;
 #define DEFINE_LOG_CATEGORY(categoryName) dirk::Logging::LogCategory categoryName{ .name = #categoryName };
@@ -22,7 +28,7 @@ enum LogLevel {
 };
 
 struct LogCategory {
-    const char* name;
+    std::string_view name;
     bool show = true;
 };
 

--- a/Engine/Source/Common/include/logging/logging.hpp
+++ b/Engine/Source/Common/include/logging/logging.hpp
@@ -35,9 +35,15 @@ public:
     Logger();
     ~Logger();
 
-    template <typename... Args>
-    void log(LogCategory category, LogLevel level, std::format_string<Args...> fmt, Args&&... args);
     void log(LogCategory category, LogLevel level, std::string str);
+
+    template <typename... Args>
+    void log(LogCategory category, LogLevel level, std::format_string<Args...> fmt, Args&&... args) {
+        if (shouldLog(category, level))
+            return;
+
+        log(category, level, std::vformat(fmt.get(), std::make_format_args(args...)));
+    }
 
     static bool shouldLog(LogCategory category, LogLevel level);
 

--- a/Engine/Source/Common/include/logging/logging.hpp
+++ b/Engine/Source/Common/include/logging/logging.hpp
@@ -33,6 +33,8 @@ struct LogCategory {
 void init();
 void shutdown();
 
+DECLARE_LOG_CATEGORY_EXTERN(Logger);
+
 class Logger {
 public:
     Logger();

--- a/Engine/Source/Common/include/logging/logging.hpp
+++ b/Engine/Source/Common/include/logging/logging.hpp
@@ -42,7 +42,7 @@ public:
 
     template <typename... Args>
     void log(LogCategory category, LogLevel level, std::format_string<Args...> fmt, Args&&... args) {
-        if (shouldLog(category, level))
+        if (!shouldLog(category, level))
             return;
 
         log(category, level, std::vformat(fmt.get(), std::make_format_args(args...)));

--- a/Engine/Source/Common/include/logging/logging.hpp
+++ b/Engine/Source/Common/include/logging/logging.hpp
@@ -34,7 +34,7 @@ public:
     Logger();
     ~Logger();
 
-    void log(LogCategory category, LogLevel level, std::string str);
+    void log(LogCategory category, LogLevel level, std::string message);
 
     template <typename... Args>
     void log(LogCategory category, LogLevel level, std::format_string<Args...> fmt, Args&&... args) {

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -26,6 +26,7 @@ void shutdown() {
 Logger::Logger() {
     // TODO: create parent directories as well
     std::filesystem::create_directory(std::filesystem::path{ logPath });
+    // TODO: clear latest.log
     logfile = std::ofstream(std::format("{}/latest.log", logPath), std::ios::out | std::ios::app);
     check(logfile.is_open());
 }
@@ -33,6 +34,7 @@ Logger::Logger() {
 Logger::~Logger() {
     logfile.flush();
     logfile.close();
+    // TODO: copy latest.log to new file with timestamp
 }
 
 static std::string makeColoredMessage(int color, const std::string& message) {

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -34,14 +34,6 @@ Logger::~Logger() {
     logfile.close();
 }
 
-template <typename... Args>
-void Logger::log(LogCategory category, LogLevel level, std::format_string<Args...> fmt, Args&&... args) {
-    if (shouldLog(category, level))
-        return;
-
-    log(category, level, std::vformat(fmt.get(), std::make_format_args(args...)));
-}
-
 void Logger::log(LogCategory category, LogLevel level, std::string message) {
     if (shouldLog(category, level))
         return;

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -46,7 +46,7 @@ Logger::~Logger() {
 
     try {
         auto now = std::chrono::system_clock::now();
-        std::string timestampedName = std::format("{}/log_{:%Y-%m-%d_%H-%M-%S}.log", logPath, now);
+        std::string timestampedName = std::format("{}/{:%Y-%m-%d_%H-%M-%S}.log", logPath, now);
 
         std::filesystem::path source = std::format("{}/latest.log", logPath);
         std::filesystem::path target = timestampedName;
@@ -104,8 +104,8 @@ void Logger::log(LogCategory category, LogLevel level, std::string message) {
     levelString += "]";
     levelColoredString += "]";
 
-    std::string msg = std::format("{} {} {} {}", timeStr, levelString, category.name, message);
-    std::string coloredMsg = std::format("{} {} {} {}", timeStr, levelColoredString, category.name, message);
+    std::string msg = std::format("{} {} {}: {}", timeStr, levelString, category.name, message);
+    std::string coloredMsg = std::format("{} {} {}: {}", timeStr, levelColoredString, category.name, message);
 
     // TODO: fix segfault
     // std::println(logfile, "{}", msg);

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -39,11 +39,11 @@ Logger::Logger() {
     archiveLogfile = std::ofstream(std::format("{}/{:%Y-%m-%d_%H-%M-%S}.log", logPath, now), std::ios::out | std::ios::trunc);
     check(archiveLogfile.is_open());
 
-    DIRK_LOG(LogLogger, INFO, "initialized logger");
+    log(LogLogger, INFO, "initialized logger");
 }
 
 Logger::~Logger() {
-    DIRK_LOG(LogLogger, INFO, "shutting down logger");
+    log(LogLogger, INFO, "shutting down logger");
 
     check(latestLogfile.is_open());
     latestLogfile.flush();

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -102,8 +102,9 @@ void Logger::log(LogCategory category, LogLevel level, std::string message) {
     levelColoredString += "]";
 
     std::string msg = std::format("{} {} {}: {}", timeStr, levelString, category.name, message);
-    std::println(latestLogfile, "{}", msg);
-    std::println(archiveLogfile, "{}", msg);
+    // TODO: fix logging segfault
+    // std::println(latestLogfile, "{}", msg);
+    // std::println(archiveLogfile, "{}", msg);
 
     std::string coloredMsg = std::format("{} {} {}: {}", timeStr, levelColoredString, category.name, message);
     std::println(std::cout, "{}", coloredMsg);

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -102,7 +102,8 @@ void Logger::log(LogCategory category, LogLevel level, std::string message) {
     std::string msg = std::format("{} {} {} {}", timeStr, levelString, category.name, message);
     std::string coloredMsg = std::format("{} {} {} {}", timeStr, levelColoredString, category.name, message);
 
-    std::println(logfile, "{}", msg);
+    // TODO: fix segfault
+    // std::println(logfile, "{}", msg);
     std::println(std::cout, "{}", coloredMsg);
 
     if (level == FATAL) {

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -83,7 +83,7 @@ void Logger::log(LogCategory category, LogLevel level, std::string message) {
     std::string msg = std::format("{} {} {} {}", time, levelString, category.name, message);
     std::string coloredMsg = std::format("{} {} {} {}", time, levelString, category.name, message);
 
-    check(logfile.is_open());
+    // why tf does this line segfault
     logfile << msg << std::endl;
     std::cout << coloredMsg << std::endl;
 }

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -24,17 +24,34 @@ void shutdown() {
 }
 
 Logger::Logger() {
-    // TODO: create parent directories as well
-    std::filesystem::create_directory(std::filesystem::path{ logPath });
-    // TODO: clear latest.log
-    logfile = std::ofstream(std::format("{}/latest.log", logPath), std::ios::out | std::ios::app);
+    std::error_code ec;
+    std::filesystem::create_directories(std::filesystem::path{ logPath }, ec);
+
+    if (ec) {
+        std::cerr << "Failed to create log directories: " << ec.message() << std::endl;
+    }
+
+    logfile = std::ofstream(std::format("{}/latest.log", logPath), std::ios::out | std::ios::trunc);
     check(logfile.is_open());
 }
 
 Logger::~Logger() {
+    check(logfile.is_open());
     logfile.flush();
     logfile.close();
-    // TODO: copy latest.log to new file with timestamp
+
+    try {
+        auto now = std::chrono::system_clock::now();
+        // Create a unique filename based on current time
+        std::string timestampedName = std::format("{}/log_{:%Y-%m-%d_%H-%M-%S}.log", logPath, now);
+
+        std::filesystem::path source = std::format("{}/latest.log", logPath);
+        std::filesystem::path target = timestampedName;
+
+        std::filesystem::copy_file(source, target, std::filesystem::copy_options::overwrite_existing);
+    } catch (const std::exception& e) {
+        std::cerr << "Failed to archive log file: " << e.what() << std::endl;
+    }
 }
 
 static std::string makeColoredMessage(int color, const std::string& message) {

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -102,10 +102,8 @@ void Logger::log(LogCategory category, LogLevel level, std::string message) {
     std::string msg = std::format("{} {} {} {}", timeStr, levelString, category.name, message);
     std::string coloredMsg = std::format("{} {} {} {}", timeStr, levelColoredString, category.name, message);
 
-    check(logfile.is_open());
-    // TODO: why tf does this line segfault
-    // logfile << msg << std::endl;
-    std::cout << coloredMsg << std::endl;
+    std::println(logfile, "{}", msg);
+    std::println(std::cout, "{}", coloredMsg);
 
     if (level == FATAL) {
         shutdown();

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -32,29 +32,26 @@ Logger::Logger() {
         std::cerr << "Failed to create log directories: " << ec.message() << std::endl;
     }
 
-    logfile = std::ofstream(std::format("{}/latest.log", logPath), std::ios::out | std::ios::trunc);
-    check(logfile.is_open());
+    latestLogfile = std::ofstream(std::format("{}/latest.log", logPath), std::ios::out | std::ios::trunc);
+    check(latestLogfile.is_open());
+
+    auto now = std::chrono::system_clock::now();
+    archiveLogfile = std::ofstream(std::format("{}/{:%Y-%m-%d_%H-%M-%S}.log", logPath, now), std::ios::out | std::ios::trunc);
+    check(archiveLogfile.is_open());
+
     DIRK_LOG(LogLogger, INFO, "initialized logger");
 }
 
 Logger::~Logger() {
     DIRK_LOG(LogLogger, INFO, "shutting down logger");
 
-    check(logfile.is_open());
-    logfile.flush();
-    logfile.close();
+    check(latestLogfile.is_open());
+    latestLogfile.flush();
+    latestLogfile.close();
 
-    try {
-        auto now = std::chrono::system_clock::now();
-        std::string timestampedName = std::format("{}/{:%Y-%m-%d_%H-%M-%S}.log", logPath, now);
-
-        std::filesystem::path source = std::format("{}/latest.log", logPath);
-        std::filesystem::path target = timestampedName;
-
-        std::filesystem::copy_file(source, target, std::filesystem::copy_options::overwrite_existing);
-    } catch (const std::exception& e) {
-        std::cerr << "Failed to archive log file: " << e.what() << std::endl;
-    }
+    check(archiveLogfile.is_open());
+    archiveLogfile.flush();
+    archiveLogfile.close();
 }
 
 static std::string makeColoredMessage(int color, const std::string& message) {
@@ -105,10 +102,10 @@ void Logger::log(LogCategory category, LogLevel level, std::string message) {
     levelColoredString += "]";
 
     std::string msg = std::format("{} {} {}: {}", timeStr, levelString, category.name, message);
-    std::string coloredMsg = std::format("{} {} {}: {}", timeStr, levelColoredString, category.name, message);
+    std::println(latestLogfile, "{}", msg);
+    std::println(archiveLogfile, "{}", msg);
 
-    // TODO: fix segfault
-    // std::println(logfile, "{}", msg);
+    std::string coloredMsg = std::format("{} {} {}: {}", timeStr, levelColoredString, category.name, message);
     std::println(std::cout, "{}", coloredMsg);
 
     if (level == FATAL) {

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -1,7 +1,6 @@
 #include "logging/logging.hpp"
 #include "asserts.hpp"
 
-#include <bits/chrono.h>
 #include <chrono>
 #include <csignal>
 #include <cstdio>
@@ -42,7 +41,6 @@ Logger::~Logger() {
 
     try {
         auto now = std::chrono::system_clock::now();
-        // Create a unique filename based on current time
         std::string timestampedName = std::format("{}/log_{:%Y-%m-%d_%H-%M-%S}.log", logPath, now);
 
         std::filesystem::path source = std::format("{}/latest.log", logPath);
@@ -104,13 +102,14 @@ void Logger::log(LogCategory category, LogLevel level, std::string message) {
     std::string msg = std::format("{} {} {} {}", timeStr, levelString, category.name, message);
     std::string coloredMsg = std::format("{} {} {} {}", timeStr, levelColoredString, category.name, message);
 
+    check(logfile.is_open());
     // TODO: why tf does this line segfault
     // logfile << msg << std::endl;
     std::cout << coloredMsg << std::endl;
 
     if (level == FATAL) {
         shutdown();
-        raise(SIGABRT);
+        std::abort();
     }
 }
 

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -1,53 +1,100 @@
 #include "logging/logging.hpp"
-#include "common.hpp"
+#include "asserts.hpp"
 
+#include <bits/chrono.h>
+#include <chrono>
+#include <cstdio>
 #include <ctime>
 #include <filesystem>
 #include <format>
 #include <fstream>
 #include <iostream>
-#include <sstream>
-#include <string_view>
+#include <memory>
+#include <ostream>
 
-namespace dirk {
+namespace dirk::Logging {
 
-constexpr std::string_view colorEnd{ "\033[0m" };
-
-std::stringstream beginLogEntry(LogCategory category, LogLevel level) {
-    std::stringstream stream{};
-
-    std::string levelString = std::format("[{}{}{}] ", getLevelColor(level), getLevelString(level), colorEnd);
-    char timestamp[25];
-    time_t now = std::time(0);
-    strftime(timestamp, sizeof(timestamp), "[%Y-%m-%d %H:%M:%S] ", localtime(&now));
-
-    stream << timestamp << levelString << category.name << ": ";
-
-    return stream;
+void init() {
+    logger = std::make_unique<Logger>();
 }
 
-void endLogEntry(std::stringstream stream) {
-    stream << colorEnd;
-    std::string out = stream.str();
+void shutdown() {
+    logger = nullptr;
+}
 
-    std::cout << out << std::endl;
+Logger::Logger() {
+    // TODO: create parent directories as well
+    std::filesystem::create_directory(std::filesystem::path{ logPath });
+    logfile = std::ofstream(std::format("{}/latest.log", logPath), std::ios::out | std::ios::app);
+    check(logfile.is_open());
+}
 
-    if (logPath == "")
+Logger::~Logger() {
+    logfile.flush();
+    logfile.close();
+}
+
+template <typename... Args>
+void Logger::log(LogCategory category, LogLevel level, std::format_string<Args...> fmt, Args&&... args) {
+    if (shouldLog(category, level))
         return;
 
-    std::filesystem::create_directory(std::filesystem::path{ logPath });
-    std::ofstream file(logPath + "/latest.log", std::ios::app);
-    check(file.is_open());
-
-    file << out << std::endl;
-
-    file.flush();
-    file.close();
-
-    // TODO: if fatal error, request engine exit
+    log(category, level, std::vformat(fmt.get(), std::make_format_args(args...)));
 }
 
-bool shouldLog(LogCategory category, LogLevel level) {
+void Logger::log(LogCategory category, LogLevel level, std::string message) {
+    if (shouldLog(category, level))
+        return;
+
+    static auto currentZone = std::chrono::current_zone();
+    const auto zonedTime = std::chrono::zoned_time{ currentZone, std::chrono::system_clock::now() };
+    const auto time = std::chrono::hh_mm_ss(zonedTime.get_local_time() - std::chrono::floor<std::chrono::days>(zonedTime.get_local_time()));
+    std::string timeStr = std::format("[{}]", time);
+
+    std::string levelString = "[";
+    std::string levelColoredString = "[";
+
+    switch (level) {
+    case TRACE:
+        levelString += "TRACE";
+        levelColoredString += "\033[36mTRACE\033[0m"; // cyan
+        break;
+    case DEBUG:
+        levelString += "DEBUG";
+        levelColoredString += "\033[34mDEBUG\033[0m"; // blue
+        break;
+    case INFO:
+        levelString += "INFO";
+        levelColoredString += "\033[32mINFO\033[0m"; // green
+        break;
+    case WARNING:
+        levelString += "WARN";
+        levelColoredString += "\033[33mWARN\033[0m"; // yellow
+        break;
+    case ERROR:
+        levelString += "ERROR";
+        levelColoredString += "\033[31mERROR\033[0m"; // red
+        break;
+    case FATAL:
+        levelString += "FATAL";
+        levelColoredString += "\033[35mFATAL\033[0m"; // magenta
+        break;
+    }
+
+    levelString += "]";
+    levelColoredString = "]";
+
+    logfile << timeStr << " " << levelString << " " << message;
+    logfile.flush();
+
+    std::println(std::cout, "{} {} {}", timeStr, levelColoredString, message);
+}
+
+bool Logger::shouldLog(LogCategory category, LogLevel level) {
+#ifdef NO_LOGGING
+    return false;
+#endif
+
     switch (level) {
 #ifndef DIRK_DEBUG_BUILD
     case DEBUG:
@@ -56,62 +103,10 @@ bool shouldLog(LogCategory category, LogLevel level) {
         return false;
 #endif
     default:
-#ifdef NO_LOGGING
-        return false;
-#else
         break;
-#endif
     }
 
     return category.show;
 }
 
-std::string getLevelString(LogLevel level) {
-    switch (level) {
-    case TRACE:
-        return "TRACE";
-    case DEBUG:
-        return "DEBUG";
-    case INFO:
-        return "INFO";
-    case WARNING:
-        return "WARN";
-    case ERROR:
-        return "ERROR";
-    case FATAL:
-        return "FATAL";
-    }
-    return "";
-}
-
-std::string getLevelColor(LogLevel level) {
-    std::string color{ "\033[" };
-
-    switch (level) {
-    case TRACE:
-        color += "36"; // cyan
-        break;
-    case DEBUG:
-        color += "34"; // blue
-        break;
-    case INFO:
-        color += "32"; // green
-        break;
-    case WARNING:
-        color += "33"; // yellow
-        break;
-    case ERROR:
-        color += "31"; // red
-        break;
-    case FATAL:
-        color += "35"; // magenta
-        break;
-    default:
-        return "";
-    }
-
-    color += "m";
-    return color;
-}
-
-} // namespace dirk
+} // namespace dirk::Logging

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -34,8 +34,12 @@ Logger::~Logger() {
     logfile.close();
 }
 
+static std::string makeColoredMessage(int color, const std::string& message) {
+    return std::format("\033[{}m{}\033[0m", color, message);
+}
+
 void Logger::log(LogCategory category, LogLevel level, std::string message) {
-    if (shouldLog(category, level))
+    if (!shouldLog(category, level))
         return;
 
     static auto currentZone = std::chrono::current_zone();
@@ -49,37 +53,39 @@ void Logger::log(LogCategory category, LogLevel level, std::string message) {
     switch (level) {
     case TRACE:
         levelString += "TRACE";
-        levelColoredString += "\033[36mTRACE\033[0m"; // cyan
+        levelColoredString += makeColoredMessage(36, "TRACE"); // cyan
         break;
     case DEBUG:
         levelString += "DEBUG";
-        levelColoredString += "\033[34mDEBUG\033[0m"; // blue
+        levelColoredString += makeColoredMessage(34, "TRACE"); // blue
         break;
     case INFO:
         levelString += "INFO";
-        levelColoredString += "\033[32mINFO\033[0m"; // green
+        levelColoredString += makeColoredMessage(32, "INFO"); // green
         break;
     case WARNING:
         levelString += "WARN";
-        levelColoredString += "\033[33mWARN\033[0m"; // yellow
+        levelColoredString += makeColoredMessage(33, "WARN"); // yellow
         break;
     case ERROR:
         levelString += "ERROR";
-        levelColoredString += "\033[31mERROR\033[0m"; // red
+        levelColoredString += makeColoredMessage(31, "ERROR"); // red
         break;
     case FATAL:
         levelString += "FATAL";
-        levelColoredString += "\033[35mFATAL\033[0m"; // magenta
+        levelColoredString += makeColoredMessage(35, "FATAL"); // magenta
         break;
     }
 
     levelString += "]";
-    levelColoredString = "]";
+    levelColoredString += "]";
 
-    logfile << timeStr << " " << levelString << " " << message;
-    logfile.flush();
+    std::string msg = std::format("{} {} {} {}", time, levelString, category.name, message);
+    std::string coloredMsg = std::format("{} {} {} {}", time, levelString, category.name, message);
 
-    std::println(std::cout, "{} {} {}", timeStr, levelColoredString, message);
+    check(logfile.is_open());
+    logfile << msg << std::endl;
+    std::cout << coloredMsg << std::endl;
 }
 
 bool Logger::shouldLog(LogCategory category, LogLevel level) {

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -81,10 +81,10 @@ void Logger::log(LogCategory category, LogLevel level, std::string message) {
     levelColoredString += "]";
 
     std::string msg = std::format("{} {} {} {}", time, levelString, category.name, message);
-    std::string coloredMsg = std::format("{} {} {} {}", time, levelString, category.name, message);
+    std::string coloredMsg = std::format("{} {} {} {}", time, levelColoredString, category.name, message);
 
-    // why tf does this line segfault
-    logfile << msg << std::endl;
+    // TODO: why tf does this line segfault
+    // logfile << msg << std::endl;
     std::cout << coloredMsg << std::endl;
 }
 

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -14,7 +14,7 @@
 
 namespace dirk::Logging {
 
-DEFINE_LOG_CATEGORY(Logger)
+static LogCategory LogLogger{ .name = "Logger" };
 
 void init() {
     logger = std::make_unique<Logger>();
@@ -34,11 +34,11 @@ Logger::Logger() {
 
     logfile = std::ofstream(std::format("{}/latest.log", logPath), std::ios::out | std::ios::trunc);
     check(logfile.is_open());
-    DIRK_LOG(Logger, INFO, "initialized logger");
+    DIRK_LOG(LogLogger, INFO, "initialized logger");
 }
 
 Logger::~Logger() {
-    DIRK_LOG(Logger, INFO, "shutting down logger");
+    DIRK_LOG(LogLogger, INFO, "shutting down logger");
 
     check(logfile.is_open());
     logfile.flush();

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -46,9 +46,10 @@ void Logger::log(LogCategory category, LogLevel level, std::string message) {
         return;
 
     static auto currentZone = std::chrono::current_zone();
-    const auto zonedTime = std::chrono::zoned_time{ currentZone, std::chrono::system_clock::now() };
-    const auto time = std::chrono::hh_mm_ss(zonedTime.get_local_time() - std::chrono::floor<std::chrono::days>(zonedTime.get_local_time()));
-    std::string timeStr = std::format("[{}]", time);
+    auto time = std::chrono::zoned_time{ currentZone, std::chrono::system_clock::now() };
+    time = std::chrono::floor<std::chrono::seconds>(time.get_local_time());
+    std::string timeStr = std::format("{:%Y/%m/%d %H:%M:%S}", time);
+    timeStr = timeStr.substr(0, 19);
 
     std::string levelString = "[";
     std::string levelColoredString = "[";
@@ -83,8 +84,8 @@ void Logger::log(LogCategory category, LogLevel level, std::string message) {
     levelString += "]";
     levelColoredString += "]";
 
-    std::string msg = std::format("{} {} {} {}", time, levelString, category.name, message);
-    std::string coloredMsg = std::format("{} {} {} {}", time, levelColoredString, category.name, message);
+    std::string msg = std::format("{} {} {} {}", timeStr, levelString, category.name, message);
+    std::string coloredMsg = std::format("{} {} {} {}", timeStr, levelColoredString, category.name, message);
 
     // TODO: why tf does this line segfault
     // logfile << msg << std::endl;

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -14,6 +14,8 @@
 
 namespace dirk::Logging {
 
+DEFINE_LOG_CATEGORY(Logger)
+
 void init() {
     logger = std::make_unique<Logger>();
 }
@@ -32,9 +34,12 @@ Logger::Logger() {
 
     logfile = std::ofstream(std::format("{}/latest.log", logPath), std::ios::out | std::ios::trunc);
     check(logfile.is_open());
+    DIRK_LOG(Logger, INFO, "initialized logger");
 }
 
 Logger::~Logger() {
+    DIRK_LOG(Logger, INFO, "shutting down logger");
+
     check(logfile.is_open());
     logfile.flush();
     logfile.close();

--- a/Engine/Source/Common/src/logging/logging.cpp
+++ b/Engine/Source/Common/src/logging/logging.cpp
@@ -3,6 +3,7 @@
 
 #include <bits/chrono.h>
 #include <chrono>
+#include <csignal>
 #include <cstdio>
 #include <ctime>
 #include <filesystem>
@@ -86,6 +87,11 @@ void Logger::log(LogCategory category, LogLevel level, std::string message) {
     // TODO: why tf does this line segfault
     // logfile << msg << std::endl;
     std::cout << coloredMsg << std::endl;
+
+    if (level == FATAL) {
+        shutdown();
+        raise(SIGABRT);
+    }
 }
 
 bool Logger::shouldLog(LogCategory category, LogLevel level) {

--- a/Engine/Source/Platform/src/platform/linux/linux.cpp
+++ b/Engine/Source/Platform/src/platform/linux/linux.cpp
@@ -105,7 +105,7 @@ vk::SurfaceKHR LinuxPlatformImpl::createTempSurface(vk::Instance instance) {
     vk::detail::DispatchLoaderDynamic dispatcher(instance, vkGetInstanceProcAddr);
     auto err = instance.createWaylandSurfaceKHR(&createInfo, nullptr, &vkSurface, dispatcher);
     if (err != vk::Result::eSuccess)
-        DIRK_LOG(LogWayland, FATAL, "received error code " << err << " while attempting to create vulkan surface for wayland surface")
+        DIRK_LOG(LogWayland, FATAL, "received error code {} while attempting to create vulkan surface for wayland surface", (int) err)
     check(vkSurface);
 
     free(wlSurface);
@@ -225,12 +225,7 @@ void LinuxPlatformImpl::wl_OutputHandleDone(void* data, struct wl_output* output
 
     monitor->getPlatform().updateMonitors();
 
-    DIRK_LOG(LogPlatform, INFO,
-             "found new monitor: "
-                 << "\n\tname: " << monitor->getName()
-                 << "\n\tmake: " << monitor->getMake()
-                 << "\n\tmodel: " << monitor->getModel()
-                 << "\n\tdescription: " << monitor->getDescription());
+    DIRK_LOG(LogPlatform, INFO, "found new monitor: \n\tname: {}\n\tmake: {}\n\tmodel: {}\n\tdescription: {}", monitor->getName(), monitor->getMake(), monitor->getModel(), monitor->getDescription())
 }
 
 void LinuxPlatformImpl::wl_OutputHandleName(void* data, struct wl_output* output, const char* name) {
@@ -468,7 +463,7 @@ constexpr Input::Key LinuxPlatformImpl::getKeyFromSym(xkb_keysym_t sym) {
     case XKB_KEY_F23: return Input::Key::F23;
     case XKB_KEY_F24: return Input::Key::F24;
     default:
-        DIRK_LOG(LogWayland, ERROR, "keycode " << sym << " is unknown")
+        DIRK_LOG(LogWayland, ERROR, "keycode {} is unknown", sym)
         return Input::Key::Unknown;
     }
     // clang-format on
@@ -487,7 +482,7 @@ constexpr Input::MouseButton LinuxPlatformImpl::getMouseFromCode(uint32_t button
     case BTN_4: return Input::MouseButton::Button4;
     case BTN_5: return Input::MouseButton::Button5;
     default:
-        DIRK_LOG(LogWayland, ERROR, "mouse button " << button << " is unknown")
+        DIRK_LOG(LogWayland, ERROR, "mouse button {} is unknown", button)
         return Input::MouseButton::Left;
     }
     // clang-format on
@@ -500,7 +495,7 @@ constexpr Input::KeyState LinuxPlatformImpl::getKeyStateFromCode(uint32_t state)
     case WL_KEYBOARD_KEY_STATE_RELEASED: return Input::KeyState::Released;
     case WL_KEYBOARD_KEY_STATE_REPEATED: return Input::KeyState::Held;
     default:
-        DIRK_LOG(LogWayland, ERROR, "key state " << state << " is unknown")
+        DIRK_LOG(LogWayland, ERROR, "key state {} is unknown", state)
         return Input::KeyState::None;
     }
     // clang-format on

--- a/Engine/Source/Platform/src/platform/linux/window.cpp
+++ b/Engine/Source/Platform/src/platform/linux/window.cpp
@@ -14,7 +14,7 @@
 
 namespace dirk::Platform::Linux {
 
-#define LOG_WAYLAND_NOT_IMPLEMENTED(feature) DIRK_LOG(LogWayland, WARNING, feature << " is not implemented in wayland");
+#define LOG_WAYLAND_NOT_IMPLEMENTED(feature) DIRK_LOG(LogWayland, WARNING, "{} is not implemented in wayland", feature);
 
 LinuxWindowImpl::LinuxWindowImpl(const WindowCreateInfo& createInfo, LinuxPlatformImpl& platformImpl)
     : linuxPlatform(platformImpl), size(createInfo.size) {
@@ -87,7 +87,7 @@ void LinuxWindowImpl::createVulkanSurface(VkInstance instance, VkSurfaceKHR* sur
 
     auto err = vkCreateWaylandSurfaceKHR(instance, createInfo, nullptr, surface);
     if (err != VK_SUCCESS)
-        DIRK_LOG(LogWayland, FATAL, "received error code " << err << " while attempting to create vulkan surface for wayland surface")
+        DIRK_LOG(LogWayland, FATAL, "received error code {} while attempting to create vulkan surface for wayland surface", (int) err)
 
     vkSurface = *surface;
     check(vkSurface);

--- a/Engine/Source/Platform/src/platform/platform.cpp
+++ b/Engine/Source/Platform/src/platform/platform.cpp
@@ -539,7 +539,7 @@ ImGuiKey Platform::keyToImGuiKey(Input::Key key)
     case Input::Key::F23: return ImGuiKey_F23;
     case Input::Key::F24: return ImGuiKey_F24;
     default:
-        DIRK_LOG(LogPlatform, ERROR, "no imgui equivalent for key " << key)
+        DIRK_LOG(LogPlatform, ERROR, "no imgui equivalent for key {}", (uint16_t) key)
         return ImGuiKey_None;
     }
 }

--- a/Engine/Source/Platform/src/platform/platform.cpp
+++ b/Engine/Source/Platform/src/platform/platform.cpp
@@ -50,7 +50,7 @@ void Platform::initImGui() {
 
     ImGuiData* bd = IM_NEW(ImGuiData)();
 
-    io.BackendPlatformUserData = (void*) bd;
+    io.BackendPlatformUserData = bd;
     io.BackendPlatformName = bd->platformName.data();
 
     // TODO: (ImGui) Enable all features

--- a/Engine/Source/Runtime/src/engine/dirkengine.cpp
+++ b/Engine/Source/Runtime/src/engine/dirkengine.cpp
@@ -20,6 +20,7 @@ IEngine* gEngine;
 
 DirkEngine::DirkEngine(const DirkEngineCreateInfo& createInfo) {
     gEngine = this;
+    Logging::init();
 
     renderer = std::make_unique<Renderer>();
     // platform needs renderer init
@@ -48,6 +49,7 @@ DirkEngine::DirkEngine(const DirkEngineCreateInfo& createInfo) {
 
 DirkEngine::~DirkEngine() {
     DIRK_LOG(LogEngine, INFO, "exiting");
+    Logging::shutdown();
 }
 
 void DirkEngine::exit() {

--- a/Engine/Source/Runtime/src/engine/dirkengine.cpp
+++ b/Engine/Source/Runtime/src/engine/dirkengine.cpp
@@ -57,7 +57,7 @@ void DirkEngine::exit() {
 }
 
 void DirkEngine::exit(const std::string& reason) {
-    DIRK_LOG(LogEngine, INFO, "engine exit has been requested with reason: " << reason);
+    DIRK_LOG(LogEngine, INFO, "engine exit has been requested with reason: {}", reason);
     this->exit();
 }
 

--- a/Engine/Source/Runtime/src/engine/world.cpp
+++ b/Engine/Source/Runtime/src/engine/world.cpp
@@ -19,7 +19,7 @@ void World::tick(float deltaTime) {
 }
 
 void World::spawnActor(const ActorCreateInfo& spawnInfo) {
-    DIRK_LOG(LogEngine, INFO, "spawning actor " << spawnInfo.name);
+    DIRK_LOG(LogEngine, INFO, "spawning actor {}", spawnInfo.name);
     auto actor = std::make_unique<Actor>(spawnInfo, *this);
     actors[actor->getName()] = std::move(actor);
 }

--- a/Engine/Source/Runtime/src/render/renderer.cpp
+++ b/Engine/Source/Runtime/src/render/renderer.cpp
@@ -37,7 +37,7 @@ namespace dirk {
 static void checkVkResult(VkResult err) {
     if (err == VK_SUCCESS)
         return;
-    DIRK_LOG(LogVulkan, ERROR, "vk::Result = " << err);
+    DIRK_LOG(LogVulkan, ERROR, "vk::Result = {}", (int) err);
 }
 
 DEFINE_LOG_CATEGORY(LogVulkan)
@@ -122,14 +122,13 @@ void Renderer::init() {
 
         vk::PhysicalDeviceProperties deviceProperties = physicalDevice.getProperties();
         // TODO: get more human readable data (like enum values)
-        DIRK_LOG(LogVulkan, INFO,
-                 "physical device selected: "
-                     << "\n\tvendor id: " << deviceProperties.vendorID
-                     << "\n\tdevice id: " << deviceProperties.deviceID
-                     << "\n\tdevice name: " << deviceProperties.deviceName
-                     //<< "\n\tdevice type: " << deviceProperties.deviceType
-                     << "\n\tapi version: " << deviceProperties.apiVersion
-                     << "\n\tdriver version: " << deviceProperties.driverVersion);
+        DIRK_LOG(LogVulkan, INFO, "physical device selected:\n\tvendor id: {}\n\tdevice id: {}\n\tdevice name: {}\n\tapi version: {}\n\tdriver version: {}",
+                 deviceProperties.vendorID,
+                 deviceProperties.deviceID,
+                 (const char*) deviceProperties.deviceName,
+                 (int) deviceProperties.deviceType,
+                 deviceProperties.apiVersion,
+                 deviceProperties.driverVersion);
 
         auto features = getDeviceFeatures(physicalDevice);
         auto formats = physicalDevice.getSurfaceFormatsKHR(surface);
@@ -444,7 +443,7 @@ bool Renderer::checkRequiredInstanceExtensions(std::vector<const char*>& extensi
                 layerFound = true;
 
         if (!layerFound) {
-            DIRK_LOG(LogVulkan, FATAL, "instance extension \"" << extensionName << "\" not found");
+            DIRK_LOG(LogVulkan, FATAL, "instance extension \"{}\" not found", extensionName);
             return false;
         }
     }
@@ -492,7 +491,7 @@ int Renderer::getDeviceSuitability(vk::PhysicalDevice device, vk::SurfaceKHR sur
 
     score += getDeviceFeatures(device).getScore();
 
-    DIRK_LOG(LogVulkan, DEBUG, "found device: " << deviceProperties.deviceName << "(score: " << score << ")");
+    DIRK_LOG(LogVulkan, DEBUG, "found device: {} (score: {})", (const char*) deviceProperties.deviceName, score);
     return score;
 }
 
@@ -585,24 +584,22 @@ vk::Bool32 Renderer::debugCallback(
     vk::DebugUtilsMessageTypeFlagsEXT messageType,
     const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData,
     void* pUserData) {
-    LogLevel level;
 
     switch (messageSeverity) {
     case vk::DebugUtilsMessageSeverityFlagBitsEXT::eError:
-        level = ERROR;
+        DIRK_LOG(LogVulkanValidation, ERROR, pCallbackData->pMessage);
         break;
     case vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning:
-        level = WARNING;
+        DIRK_LOG(LogVulkanValidation, WARNING, pCallbackData->pMessage);
         break;
     case vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo:
-        level = INFO;
+        DIRK_LOG(LogVulkanValidation, INFO, pCallbackData->pMessage);
         break;
     case vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose:
-        level = DEBUG;
+        DIRK_LOG(LogVulkanValidation, DEBUG, pCallbackData->pMessage);
         break;
     }
 
-    DIRK_LOG(LogVulkanValidation, level, pCallbackData->pMessage);
     return vk::False;
 }
 
@@ -616,7 +613,7 @@ bool Renderer::checkValidationLayerSupport() {
                 layerFound = true;
 
         if (!layerFound) {
-            DIRK_LOG(LogVulkan, ERROR, "validation layer \"" << layerName << "\" not found");
+            DIRK_LOG(LogVulkan, ERROR, "validation layer \"{}\" not found", layerName);
             return false;
         }
     }

--- a/Engine/Source/Runtime/src/resources/resource_manager.cpp
+++ b/Engine/Source/Runtime/src/resources/resource_manager.cpp
@@ -32,15 +32,15 @@ std::shared_ptr<const Model> ResourceManager::loadModel(const std::string& name)
 
     if (warn != "") {
         warn.pop_back(); // remove trailing return
-        DIRK_LOG(LogResourceManager, WARNING, "tinygltf: " << warn);
+        DIRK_LOG(LogResourceManager, WARNING, "tinygltf: {}", warn);
     }
     if (err != "") {
         err.pop_back(); // remove trailing return
-        DIRK_LOG(LogResourceManager, ERROR, "tinygltf: " << err);
+        DIRK_LOG(LogResourceManager, ERROR, "tinygltf: {}", err);
     }
 
     if (!ret) {
-        DIRK_LOG(LogResourceManager, FATAL, "failed to load model: " << name);
+        DIRK_LOG(LogResourceManager, FATAL, "failed to load model {}", name);
         return nullptr;
     }
 
@@ -145,7 +145,7 @@ std::shared_ptr<const Shader> ResourceManager::loadShader(const std::string& nam
     std::ifstream file(std::string(shaderPath) + "/" + name + ".spv", std::ios::ate | std::ios::binary);
 
     if (!file.is_open()) {
-        DIRK_LOG(LogResourceManager, FATAL, "unable to load shader: " << name)
+        DIRK_LOG(LogResourceManager, FATAL, "unable to load shader {}", name)
         return nullptr;
     }
 

--- a/Engine/Thirdparty/ImGui/ImGui.dirkmod
+++ b/Engine/Thirdparty/ImGui/ImGui.dirkmod
@@ -6,7 +6,6 @@
         "vulkan"
     ],
     "defines": {
-        "IMGUI_IMPL_VULKAN_HAS_DYNAMIC_RENDERING": "",
         "IMGUI_DISABLE_OBSOLETE_FUNCTIONS": ""
     }
 }


### PR DESCRIPTION
## Summary of the PR

Major improvements to logging and assertions to make QoL a lot easier

## Issues linked to the PR: Closes #16 

## TODO

- [x] Change archiving
  - On init, always open two files: new file with current timestamp + truncated `latest.log` file
  - On log, write to both files
  - On shutdown, close both files properly
- [x] Log logger's init & shutdown

## Changes

- Have logging use formatting instead of the weird thing with ostreams
- Init & shutdown system for logging, helps with managing log files
- Make assertion use the logging system (just does a FATAL log)
- Allow asserting with a message