### PR TITLE
Make sure make tracks dependencies generated by gcc

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,10 +4,13 @@ changelog:
       - documentation
       - ci-cd
   categories:
-    - title: DirkBuildTool
+    - title: Build Tool
       labels:
         - build-tool
-    - title: Features
+    - title: Platform
+      labels:
+        - platform
+    - title: Other Features
       labels:
         - enhancement
     - title: Bugs and Optimizations

--- a/Engine/Programs/DirkBuildTool/Source/make/makefiles/base.make
+++ b/Engine/Programs/DirkBuildTool/Source/make/makefiles/base.make
@@ -23,6 +23,9 @@ SRC=$(shell find $(SRC_DIR) -name '*$(SRC_EXT)')
 
 OBJ_DIR=$(INT_DIR)/obj
 OBJ=$(SRC:$(SRC_DIR)/%$(SRC_EXT)=$(OBJ_DIR)/%.o)
+DEP = $(OBJ:.o=.d)
+
+-include $(DEP)
 
 .PHONY: $(TARGET)
 $(TARGET): $(OUT)


### PR DESCRIPTION
`make` now actually uses generated `.d` files when building objects.
Update `release.yml` for new tags.

Closes #66 