### PR TITLE
[FEAT] Fix the rendering of Engine viewports + make a simple editor UI

### DIFF
--- a/Engine/Source/Platform/src/platform/platform.cpp
+++ b/Engine/Source/Platform/src/platform/platform.cpp
@@ -102,7 +102,6 @@ void Platform::tick(float deltaTime) {
     ImGuiPlatformData* bd = getBackendData();
     check(bd);
 
-    io.DeltaTime = deltaTime;
     io.DisplaySize = bd->mainWindow->getSize();
 
     // TODO: framebuffer scale

--- a/Engine/Source/Runtime/include/engine/dirkengine.hpp
+++ b/Engine/Source/Runtime/include/engine/dirkengine.hpp
@@ -41,8 +41,9 @@ private:
     std::shared_ptr<World> world;
 
 private:
-    void tick(float deltaTime);
+    bool tick(float deltaTime);
     float captureDeltaTime();
+    void renderImGui();
 
     std::chrono::high_resolution_clock::time_point lastTick;
     bool requestingExit = false;

--- a/Engine/Source/Runtime/include/engine/dirkengine.hpp
+++ b/Engine/Source/Runtime/include/engine/dirkengine.hpp
@@ -43,10 +43,13 @@ private:
 private:
     bool tick(float deltaTime);
     float captureDeltaTime();
-    void renderImGui();
+    void renderImGui(float deltaTime);
 
     std::chrono::high_resolution_clock::time_point lastTick;
     bool requestingExit = false;
+
+    // ImGui UI state
+    bool showDemoWindow, showStyleEditor;
 };
 
 } // namespace dirk

--- a/Engine/Source/Runtime/include/render/renderer.hpp
+++ b/Engine/Source/Runtime/include/render/renderer.hpp
@@ -60,12 +60,16 @@ public:
     ~Renderer();
 
     void init(vk::SurfaceKHR surface);
-    void initImGui(vk::SurfaceKHR surface);
+    void ImGui_init(vk::SurfaceKHR surface);
     void render();
-    void shutdownImGui();
+    void ImGui_shutdown();
 
-    std::shared_ptr<Viewport> createViewport(const ViewportCreateInfo& createInfo);
-    void destroyViewport(std::shared_ptr<Viewport> viewport);
+    void ImGui_beginFrame();
+    void ImGui_render();
+
+    std::unique_ptr<Viewport>& createViewport(const ViewportCreateInfo& createInfo);
+    void destroyViewport(std::unique_ptr<Viewport>& viewport);
+    std::vector<std::unique_ptr<Viewport>>& getViewports() { return viewports; }
 
     std::vector<SwapchainImage> createSwapChain(const SwapChainCreateInfo& createInfo);
 
@@ -91,7 +95,7 @@ public:
     vk::Extent2D chooseSwapExtent(vk::Extent2D windowSize, const vk::SurfaceCapabilitiesKHR& capabilities);
 
 private:
-    std::vector<std::shared_ptr<Viewport>> viewports;
+    std::vector<std::unique_ptr<Viewport>> viewports;
     ImGuiViewportRendererData* mainViewportData = nullptr; // TODO: remove for custom backend
 
 private:
@@ -101,9 +105,9 @@ private:
     bool checkDeviceExtensionSupport(vk::PhysicalDevice device);
     QueueFamilyIndices findQueueFamilies(vk::PhysicalDevice device, vk::SurfaceKHR surface);
 
-    void createImGuiWindow(ImGuiViewport* viewport);
-    void renderImGuiWindow(ImGuiViewport* viewport);
-    void destroyImGuiWindow(ImGuiViewport* viewport);
+    void ImGui_createWindow(ImGuiViewport* viewport);
+    void ImGui_renderWindow(ImGuiViewport* viewport);
+    void ImGui_destroyWindow(ImGuiViewport* viewport);
 
 #ifdef ENABLE_VALIDATION_LAYERS
 private:

--- a/Engine/Source/Runtime/include/render/viewport.hpp
+++ b/Engine/Source/Runtime/include/render/viewport.hpp
@@ -43,6 +43,7 @@ private:
     // this will create render pass, pipeline and all associated stuff. this should only be called
     // on resize
     void createRenderResources();
+    void cleanupRenderResources();
 
     std::unique_ptr<Camera> camera;
 

--- a/Engine/Source/Runtime/include/render/viewport.hpp
+++ b/Engine/Source/Runtime/include/render/viewport.hpp
@@ -37,7 +37,7 @@ public:
 
     vk::SubmitInfo render();
     void renderImGui();
-    void resize(vk::Extent2D inSize) { size = inSize; }
+    void resize(vk::Extent2D inSize);
 
 private:
     // this will create render pass, pipeline and all associated stuff. this should only be called

--- a/Engine/Source/Runtime/src/engine/dirkengine.cpp
+++ b/Engine/Source/Runtime/src/engine/dirkengine.cpp
@@ -61,12 +61,12 @@ DirkEngine::DirkEngine(const DirkEngineCreateInfo& createInfo) {
         style.Colors[ImGuiCol_WindowBg].w = 1.0f;
 
         platform->initImGui();
-        renderer->initImGui(platform->createTempSurface(renderer->getResources().instance));
+        renderer->ImGui_init(platform->createTempSurface(renderer->getResources().instance));
     }
 
     // initial engine state
     {
-        auto viewport = renderer->createViewport(ViewportCreateInfo{
+        auto& viewport = renderer->createViewport(ViewportCreateInfo{
             .name = "Hello World!",
             .size = vk::Extent2D(500, 500),
             .world = world,
@@ -81,10 +81,11 @@ DirkEngine::DirkEngine(const DirkEngineCreateInfo& createInfo) {
         if (isRequestingExit())
             break;
 
-        tick(deltaTime);
+        if (!tick(deltaTime))
+            break;
     }
 
-    renderer->shutdownImGui();
+    renderer->ImGui_shutdown();
     platform->shutdownImGui();
 }
 
@@ -102,15 +103,26 @@ void DirkEngine::exit(const std::string& reason) {
     this->exit();
 }
 
-void DirkEngine::tick(float deltaTime) {
+bool DirkEngine::tick(float deltaTime) {
     platform->tick(deltaTime);
     // in case we fail platform event polling
     if (isRequestingExit())
-        return;
+        return false;
 
     world->tick(deltaTime);
 
     renderer->render();
+
+    // ImGui
+    {
+        renderer->ImGui_beginFrame();
+        ImGui::NewFrame();
+        renderImGui();
+        ImGui::Render();
+        renderer->ImGui_render();
+    }
+
+    return !isRequestingExit();
 }
 
 float DirkEngine::captureDeltaTime() {
@@ -125,6 +137,15 @@ float DirkEngine::captureDeltaTime() {
     // DIRK_LOG(LogDirkEngine, INFO) << "fps: " << 1.0 / deltaTime;
 
     return deltaTime;
+}
+
+void DirkEngine::renderImGui() {
+    // TODO: process all ImGui rendering
+    ImGui::ShowDemoWindow();
+
+    for (auto& viewport : renderer->getViewports()) {
+        viewport->renderImGui();
+    }
 }
 
 } // namespace dirk

--- a/Engine/Source/Runtime/src/engine/dirkengine.cpp
+++ b/Engine/Source/Runtime/src/engine/dirkengine.cpp
@@ -163,7 +163,7 @@ void DirkEngine::renderImGui(float deltaTime) {
     ImGui::Begin("Editor Panel");
     {
         ImGui::Text("FPS: %f", 1.0 / deltaTime);
-        ImGui::Text("Frame Time: %f", deltaTime);
+        ImGui::Text("Frame Time: %fms", deltaTime * 1000);
 
         ImGui::Checkbox("Show Demo Window", &showDemoWindow);
         ImGui::Checkbox("Show Style Editor", &showStyleEditor);

--- a/Engine/Source/Runtime/src/engine/dirkengine.cpp
+++ b/Engine/Source/Runtime/src/engine/dirkengine.cpp
@@ -120,7 +120,7 @@ bool DirkEngine::tick(float deltaTime) {
         io.DeltaTime = deltaTime;
         renderer->ImGui_beginFrame();
         ImGui::NewFrame();
-        renderImGui();
+        renderImGui(deltaTime);
         ImGui::Render();
         renderer->ImGui_render();
     }
@@ -135,14 +135,10 @@ float DirkEngine::captureDeltaTime() {
 
     lastTick = currentTime;
 
-    // TODO: have main editor engine ImGui window that displays these things
-    // DIRK_LOG(LogDirkEngine, INFO) << "delta time: " << deltaTime;
-    // DIRK_LOG(LogDirkEngine, INFO) << "fps: " << 1.0 / deltaTime;
-
     return deltaTime;
 }
 
-void DirkEngine::renderImGui() {
+void DirkEngine::renderImGui(float deltaTime) {
     // Make main parent window
     ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoDocking;
 
@@ -153,11 +149,35 @@ void DirkEngine::renderImGui() {
     windowFlags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
     windowFlags |= ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;
 
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+
     ImGui::PushStyleColor(ImGuiCol_MenuBarBg, ImVec4{ .0f, .0f, .0f, .0f });
     ImGui::Begin("DockSpace", nullptr, windowFlags);
     ImGui::PopStyleColor(); // MenuBarBg
+    ImGui::PopStyleVar(3);
 
     ImGui::DockSpace(ImGui::GetID("DirkDockspace"));
+
+    ImGui::Begin("Editor Panel");
+    {
+        ImGui::Text("FPS: %f", 1.0 / deltaTime);
+        ImGui::Text("Frame Time: %f", deltaTime);
+
+        ImGui::Checkbox("Show Demo Window", &showDemoWindow);
+        ImGui::Checkbox("Show Style Editor", &showStyleEditor);
+    }
+    ImGui::End();
+
+    if (showDemoWindow)
+        ImGui::ShowDemoWindow();
+
+    if (showStyleEditor) {
+        ImGui::Begin("ImGui style editor", &showStyleEditor);
+        ImGui::ShowStyleEditor();
+        ImGui::End();
+    }
 
     for (auto& viewport : renderer->getViewports()) {
         viewport->renderImGui();

--- a/Engine/Source/Runtime/src/engine/dirkengine.cpp
+++ b/Engine/Source/Runtime/src/engine/dirkengine.cpp
@@ -2,6 +2,7 @@
 
 #include "common.hpp"
 #include "engine/world.hpp"
+#include "imgui.h"
 #include "render/renderer.hpp"
 #include "render/viewport.hpp"
 #include "vulkan/vulkan_structs.hpp"
@@ -140,12 +141,27 @@ float DirkEngine::captureDeltaTime() {
 }
 
 void DirkEngine::renderImGui() {
-    // TODO: process all ImGui rendering
-    ImGui::ShowDemoWindow();
+    // Make main parent window
+    ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoDocking;
+
+    ImGuiViewport* viewport = ImGui::GetMainViewport();
+    ImGui::SetNextWindowPos(viewport->Pos);
+    ImGui::SetNextWindowSize(viewport->Size);
+    ImGui::SetNextWindowViewport(viewport->ID);
+    windowFlags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
+    windowFlags |= ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;
+
+    ImGui::PushStyleColor(ImGuiCol_MenuBarBg, ImVec4{ .0f, .0f, .0f, .0f });
+    ImGui::Begin("DockSpace", nullptr, windowFlags);
+    ImGui::PopStyleColor(); // MenuBarBg
+
+    ImGui::DockSpace(ImGui::GetID("DirkDockspace"));
 
     for (auto& viewport : renderer->getViewports()) {
         viewport->renderImGui();
     }
+
+    ImGui::End();
 }
 
 } // namespace dirk

--- a/Engine/Source/Runtime/src/engine/dirkengine.cpp
+++ b/Engine/Source/Runtime/src/engine/dirkengine.cpp
@@ -116,6 +116,8 @@ bool DirkEngine::tick(float deltaTime) {
 
     // ImGui
     {
+        ImGuiIO& io = ImGui::GetIO();
+        io.DeltaTime = deltaTime;
         renderer->ImGui_beginFrame();
         ImGui::NewFrame();
         renderImGui();

--- a/Engine/Source/Runtime/src/render/renderer.cpp
+++ b/Engine/Source/Runtime/src/render/renderer.cpp
@@ -236,7 +236,15 @@ void Renderer::init(vk::SurfaceKHR surface) {
     DIRK_LOG(LogVulkan, INFO, "vulkan initialized successfully");
 }
 
-void Renderer::initImGui(vk::SurfaceKHR surface) {
+Renderer::~Renderer() {
+    // make sure all device ops are finished
+    device.waitIdle();
+    DIRK_LOG(LogVulkan, INFO, "cleaning up renderer");
+
+    viewports.clear();
+}
+
+void Renderer::ImGui_init(vk::SurfaceKHR surface) {
     auto formats = physicalDevice.getSurfaceFormatsKHR(surface);
     auto capabilities = physicalDevice.getSurfaceCapabilitiesKHR(surface);
     auto swapChainImageFormat = chooseSwapSurfaceFormat(formats);
@@ -250,7 +258,7 @@ void Renderer::initImGui(vk::SurfaceKHR surface) {
     pipelineRenderingCreateInfo.pColorAttachmentFormats = &swapChainImageFormat.format;
     pipelineRenderingCreateInfo.depthAttachmentFormat = properties.depthFormat;
 
-    createImGuiWindow(nullptr);
+    ImGui_createWindow(nullptr);
 
     ImGui_ImplVulkan_InitInfo initInfo = {};
     initInfo.Instance = instance;
@@ -270,61 +278,41 @@ void Renderer::initImGui(vk::SurfaceKHR surface) {
     ImGui_ImplVulkan_Init(&initInfo);
 }
 
-void Renderer::shutdownImGui() {
-    destroyImGuiWindow(nullptr);
+void Renderer::ImGui_shutdown() {
+    ImGui_destroyWindow(nullptr);
     ImGui_ImplVulkan_Shutdown();
-}
-
-Renderer::~Renderer() {
-    // make sure all device ops are finished
-    device.waitIdle();
-    DIRK_LOG(LogVulkan, INFO, "cleaning up renderer");
-
-    viewports.clear();
 }
 
 void Renderer::render() {
     checkVulkan(device.waitForFences(1, &inFlightFence, vk::True, UINT64_MAX));
     checkVulkan(device.resetFences(1, &inFlightFence));
 
-    // viewports
-    {
-        std::vector<vk::SubmitInfo> submitInfos(viewports.size());
-        for (auto& viewport : viewports) {
-            submitInfos.emplace_back(viewport->render());
-        }
-        checkVulkan(queues.graphicsQueue.submit(submitInfos.size(), submitInfos.data(), inFlightFence));
+    std::vector<vk::SubmitInfo> submitInfos(viewports.size());
+    for (auto& viewport : viewports) {
+        submitInfos.emplace_back(viewport->render());
     }
-
-    // ImGui
-    {
-        ImGui_ImplVulkan_NewFrame();
-        ImGui::NewFrame();
-
-        // TODO: process all ImGui rendering
-        ImGui::ShowDemoWindow();
-
-        for (auto& viewport : viewports) {
-            viewport->renderImGui();
-        }
-
-        ImGui::Render();
-
-        checkVulkan(device.waitForFences(1, &inFlightFence, vk::True, UINT64_MAX));
-        checkVulkan(device.resetFences(1, &inFlightFence));
-
-        renderImGuiWindow(nullptr);
-
-        ImGui::UpdatePlatformWindows();
-        ImGui::RenderPlatformWindowsDefault();
-    }
+    checkVulkan(queues.graphicsQueue.submit(submitInfos.size(), submitInfos.data(), inFlightFence));
 }
 
-std::shared_ptr<Viewport> Renderer::createViewport(const ViewportCreateInfo& createInfo) {
-    return viewports.emplace_back(std::make_shared<Viewport>(createInfo));
+void Renderer::ImGui_beginFrame() {
+    ImGui_ImplVulkan_NewFrame();
 }
 
-void Renderer::destroyViewport(std::shared_ptr<Viewport> viewport) {
+void Renderer::ImGui_render() {
+    checkVulkan(device.waitForFences(1, &inFlightFence, vk::True, UINT64_MAX));
+    checkVulkan(device.resetFences(1, &inFlightFence));
+
+    ImGui_renderWindow(nullptr);
+
+    ImGui::UpdatePlatformWindows();
+    ImGui::RenderPlatformWindowsDefault();
+}
+
+std::unique_ptr<Viewport>& Renderer::createViewport(const ViewportCreateInfo& createInfo) {
+    return viewports.emplace_back(std::make_unique<Viewport>(createInfo));
+}
+
+void Renderer::destroyViewport(std::unique_ptr<Viewport>& viewport) {
     viewports.erase(std::find(viewports.begin(), viewports.end(), viewport));
 }
 
@@ -965,7 +953,7 @@ QueueFamilyIndices Renderer::findQueueFamilies(vk::PhysicalDevice device, vk::Su
     return indices;
 }
 
-void Renderer::createImGuiWindow(ImGuiViewport* viewport) {
+void Renderer::ImGui_createWindow(ImGuiViewport* viewport) {
     ImGuiViewportRendererData* vd = IM_NEW(ImGuiViewportRendererData)();
     if (viewport) {
         viewport->RendererUserData = vd;
@@ -985,7 +973,7 @@ void Renderer::createImGuiWindow(ImGuiViewport* viewport) {
     vd->commandBuffer = gEngine->getRenderer()->createCommandBuffer();
 }
 
-void Renderer::renderImGuiWindow(ImGuiViewport* viewport) {
+void Renderer::ImGui_renderWindow(ImGuiViewport* viewport) {
     ImGuiViewportRendererData* vd = nullptr;
     if (viewport) {
         vd = (ImGuiViewportRendererData*) viewport->RendererUserData;
@@ -1105,7 +1093,7 @@ void Renderer::renderImGuiWindow(ImGuiViewport* viewport) {
         checkVulkan(result);
 }
 
-void Renderer::destroyImGuiWindow(ImGuiViewport* viewport) {
+void Renderer::ImGui_destroyWindow(ImGuiViewport* viewport) {
     ImGuiViewportRendererData* vd = nullptr;
     if (viewport) {
         vd = (ImGuiViewportRendererData*) viewport->RendererUserData;

--- a/Engine/Source/Runtime/src/render/viewport.cpp
+++ b/Engine/Source/Runtime/src/render/viewport.cpp
@@ -318,6 +318,21 @@ void Viewport::renderImGui() {
     ImGui::PopStyleVar();
 }
 
+void Viewport::resize(vk::Extent2D inSize) {
+    if ((inSize.width == size.width && inSize.height == size.height) || inSize.width == 0 || inSize.height == 0) {
+        return;
+    }
+
+    size = inSize;
+    camera->resize(size);
+
+    auto device = gEngine->getRenderer()->getResources().device;
+    device.waitIdle();
+
+    ImGui_ImplVulkan_RemoveTexture(descriptorSet);
+    createRenderResources();
+}
+
 void Viewport::setWorld(std::shared_ptr<World> inWorld) { world = inWorld; }
 
 } // namespace dirk

--- a/Engine/Source/Runtime/src/render/viewport.cpp
+++ b/Engine/Source/Runtime/src/render/viewport.cpp
@@ -46,7 +46,7 @@ Viewport::Viewport(const ViewportCreateInfo& createInfo)
 }
 
 Viewport::~Viewport() {
-    ImGui_ImplVulkan_RemoveTexture(descriptorSet);
+    cleanupRenderResources();
 }
 
 void Viewport::createRenderResources() {
@@ -235,6 +235,10 @@ void Viewport::createRenderResources() {
     descriptorSet = ImGui_ImplVulkan_AddTexture(sampler, outImageMemoryView.view, (VkImageLayout) vk::ImageLayout::eShaderReadOnlyOptimal);
 }
 
+void Viewport::cleanupRenderResources() {
+    ImGui_ImplVulkan_RemoveTexture(descriptorSet);
+}
+
 vk::SubmitInfo Viewport::render() {
     auto properties = gEngine->getRenderer()->getProperties();
     commandBuffer.reset();
@@ -329,7 +333,7 @@ void Viewport::resize(vk::Extent2D inSize) {
     auto device = gEngine->getRenderer()->getResources().device;
     device.waitIdle();
 
-    ImGui_ImplVulkan_RemoveTexture(descriptorSet);
+    cleanupRenderResources();
     createRenderResources();
 }
 

--- a/Engine/Source/Runtime/src/render/viewport.cpp
+++ b/Engine/Source/Runtime/src/render/viewport.cpp
@@ -307,9 +307,15 @@ vk::SubmitInfo Viewport::render() {
 }
 
 void Viewport::renderImGui() {
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
     ImGui::Begin(name.data());
-    ImGui::Image((ImTextureID) (VkDescriptorSet) descriptorSet, ImVec2(size.width, size.height));
+
+    resize(ImGui::GetContentRegionAvail());
+
+    ImGui::Image((ImTextureID) (VkDescriptorSet) descriptorSet, size);
+
     ImGui::End();
+    ImGui::PopStyleVar();
 }
 
 void Viewport::setWorld(std::shared_ptr<World> inWorld) { world = inWorld; }


### PR DESCRIPTION
## Summary of the PR

Setup proper rendering & resizing of viewports. Also added a basic menu with style editor, ImGui demo window & some stats.

## Issues linked to the PR: Closes #80 

## Changes

- `ImGuiIO.DeltaTime` is now set by `DirkEngine` (no longer platform)
- `DirkEngine::tick` now returns bool. If returns false, will exit game loop (to use in case some stuff during tick can fail)
- `DirkEngine` now handles rendering the main ImGui parent window and main settings window.
- `Renderer`: store viewports as unique pointers (not shared)
- `Renderer`: rename ImGui related functions + split different rendering stages into different functions that are called in `DirkEngine::tick`
- Fix resizing of `Viewport`
- Create basic "Editor Panel". It display FPS & FrameTime as well as check boxes for ImGui style editor & for the demo window.
- `Viewport::renderImGui`: properly renders the viewport, resizes if needed, disabled collapsing

