### PR TITLE
fix: a lot of build warnings

### DIFF
--- a/Engine/Programs/DirkBuildTool/Source/main.go
+++ b/Engine/Programs/DirkBuildTool/Source/main.go
@@ -14,6 +14,11 @@ func usage() {
 	fmt.Printf("usage: DirkBuildTool [target] [build type]\n")
 }
 
+const (
+	defaultTarget    = "Editor"
+	defaultBuildType = "Development"
+)
+
 func main() {
 	if err := config.LoadConfig(); err != nil {
 		panic(err)
@@ -31,11 +36,11 @@ func main() {
 	buildType := ""
 	switch len(os.Args) {
 	case 1:
-		target = "Editor"
-		buildType = "Development"
+		target = defaultTarget
+		buildType = defaultBuildType
 	case 2:
 		target = os.Args[1]
-		buildType = "Development"
+		buildType = defaultBuildType
 	case 3:
 		target = os.Args[1]
 		buildType = os.Args[2]

--- a/Engine/Programs/DirkBuildTool/Source/module/cpp.go
+++ b/Engine/Programs/DirkBuildTool/Source/module/cpp.go
@@ -72,7 +72,33 @@ func (m *CppModule) GenerateCompileCommands() (models.CompileCommands, error) {
 			}
 		}
 
-		command := []string{"g++", "-fPIC", fmt.Sprintf("-std=%s", m.Std)}
+		command := []string{"g++"}
+
+		var warningFlags []string
+		switch m.build.Mode.WarningLevel {
+		case config.WarningLevelNone:
+			warningFlags = []string{"-w"}
+		case config.WarningLevelLow:
+			warningFlags = []string{"-Wall"}
+		case config.WarningLevelMedium:
+			warningFlags = []string{"-Wall", "-Wextra"}
+		case config.WarningLevelMax:
+			warningFlags = []string{
+				"-Wall",
+				"-Wextra",
+				"-Wpedantic",
+				"-Wshadow",
+				"-Wnon-virtual-dtor",
+				"-Wold-style-cast",
+				"-Woverloaded-virtual",
+				"-Wunused-parameter",
+				"-Wnull-dereference",
+			}
+		}
+
+		cFlags := append(m.build.Mode.CompileFlags, warningFlags...)
+		cFlags = append(cFlags, "-fPIC", fmt.Sprintf("-std=%s", m.Std))
+		command = append(command, cFlags...)
 
 		for _, dir := range incDirs {
 			command = append(command, fmt.Sprintf("-I%s", dir))

--- a/Engine/Source/Core/include/core.hpp
+++ b/Engine/Source/Core/include/core.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#define DIRK_UNUSED(var) ((void) (var))
+
 #include "Events/EventManager.hpp"
 #include "asserts.hpp"
 #include "logging/logging.hpp"

--- a/Engine/Source/Platform/include/platform/linux/window.hpp
+++ b/Engine/Source/Platform/include/platform/linux/window.hpp
@@ -43,12 +43,12 @@ private:
     static void xdg_ToplevelClose(void* data, xdg_toplevel* toplevel);
 
 private:
+    LinuxPlatformImpl& linuxPlatform;
+
     // window properties
     vk::Extent2D size;
     std::string_view title;
     bool decorated;
-
-    LinuxPlatformImpl& linuxPlatform;
 
     wl_surface* wlSurface = nullptr;
     xdg_surface* xdgSurface = nullptr;
@@ -61,7 +61,7 @@ private:
     bool fullscreen = false;
 
     glm::vec2 pos;
-    glm::vec2 savedPos; // saved on fullscreen to restore previous position
+    glm::vec2 savedPos = { 0.f, 0.f }; // saved on fullscreen to restore previous position
 
     friend LinuxPlatformImpl;
 };

--- a/Engine/Source/Platform/include/platform/monitor.hpp
+++ b/Engine/Source/Platform/include/platform/monitor.hpp
@@ -11,7 +11,7 @@ namespace dirk::Platform {
 
 struct VideoMode {
     vk::Extent2D size = { 0, 0 };
-    std::uint32_t red, green, blue = 8;
+    std::uint32_t red = 0, green = 0, blue = 8;
     std::uint32_t refreshRate = 60;
 };
 

--- a/Engine/Source/Platform/include/platform/platform.hpp
+++ b/Engine/Source/Platform/include/platform/platform.hpp
@@ -31,8 +31,8 @@ struct WindowCreateInfo {
 
     PlatformWindowImpl* parent = nullptr;
 
-    bool focused;
-    bool decorated;
+    bool focused = false;
+    bool decorated = false;
     // TODO: create floating window
     // bool floating;
 };

--- a/Engine/Source/Platform/src/platform/linux/linux.cpp
+++ b/Engine/Source/Platform/src/platform/linux/linux.cpp
@@ -34,6 +34,8 @@ DEFINE_LOG_CATEGORY(LogWayland)
 
 LinuxPlatformImpl::LinuxPlatformImpl(const PlatformCreateInfo& createInfo, Platform& platform)
     : platform(platform) {
+    DIRK_UNUSED(createInfo);
+
     display = wl_display_connect(nullptr);
     if (!display) {
         DIRK_LOG(LogWayland, FATAL, "failed to create wayland display")
@@ -50,7 +52,7 @@ LinuxPlatformImpl::LinuxPlatformImpl(const PlatformCreateInfo& createInfo, Platf
 
     static const struct wl_registry_listener registryListener = {
         .global = wl_GlobalRegistryHandler,
-        .global_remove = [](void* data, struct wl_registry* registry, uint32_t name) {},
+        .global_remove = [](void*, struct wl_registry*, uint32_t) {},
     };
     wl_registry_add_listener(registry, &registryListener, this);
 
@@ -119,13 +121,12 @@ std::string_view LinuxPlatformImpl::getClipboardText() {
 }
 
 void LinuxPlatformImpl::setClipboardText(const std::string& text) {
+    DIRK_UNUSED(text);
     // TODO: clipboard
     DIRK_LOG(LogWayland, ERROR, "clipboard not implemented");
 }
 
 void LinuxPlatformImpl::beginDrag(LinuxWindowImpl& window, glm::vec2 offset) {
-    auto* bd = platform.getBackendData();
-
     check(toplevelDragManager && dataDeviceManager && seat);
 
     // Don't start a new drag if one is already in progress
@@ -235,7 +236,7 @@ void LinuxPlatformImpl::wl_GlobalRegistryHandler(void* data, struct wl_registry*
         // xdg_wm_base
         platform->xdgWmBase = static_cast<xdg_wm_base*>(wl_registry_bind(registry, name, &xdg_wm_base_interface, version));
         static const struct xdg_wm_base_listener xdgWmBaseListener = {
-            .ping = [](void* data, struct xdg_wm_base* xdg_wm_base, uint32_t serial) { xdg_wm_base_pong(xdg_wm_base, serial); },
+            .ping = [](void*, struct xdg_wm_base* xdgWmBase, uint32_t serial) { xdg_wm_base_pong(xdgWmBase, serial); },
         };
         xdg_wm_base_add_listener(platform->xdgWmBase, &xdgWmBaseListener, platform);
     } else if (strcmp(interface, wl_seat_interface.name) == 0) {
@@ -243,7 +244,7 @@ void LinuxPlatformImpl::wl_GlobalRegistryHandler(void* data, struct wl_registry*
         platform->seat = static_cast<wl_seat*>(wl_registry_bind(registry, name, &wl_seat_interface, version));
         static const wl_seat_listener seatListener = {
             .capabilities = wl_SeatCapabilities,
-            .name = [](void*, struct wl_seat*, const char* name) {},
+            .name = [](void*, struct wl_seat*, const char*) {},
         };
         wl_seat_add_listener(platform->seat, &seatListener, platform);
     } else if (strcmp(interface, wl_output_interface.name) == 0) {
@@ -296,7 +297,7 @@ void LinuxPlatformImpl::wl_SeatCapabilities(void* data, wl_seat* seat, uint32_t 
             .leave = wl_KeyboardLeave,
             .key = wl_KeyboardKey,
             .modifiers = wl_KeyboardModifiers,
-            .repeat_info = [](void* data, struct wl_keyboard* keyboard, int32_t rate, int32_t delay) {},
+            .repeat_info = [](void*, struct wl_keyboard*, int32_t, int32_t) {},
         };
         wl_keyboard_add_listener(platform->keyboard, &keyboardListener, platform);
     }
@@ -306,6 +307,11 @@ void LinuxPlatformImpl::wl_SeatCapabilities(void* data, wl_seat* seat, uint32_t 
 }
 
 void LinuxPlatformImpl::wl_OutputHandleGeometry(void* data, struct wl_output* output, int32_t x, int32_t y, int32_t physicalWidth, int32_t physicalHeight, int32_t subpixel, const char* make, const char* model, int32_t transform) {
+    DIRK_UNUSED(physicalWidth);
+    DIRK_UNUSED(physicalHeight);
+    DIRK_UNUSED(subpixel);
+    DIRK_UNUSED(transform);
+
     auto* monitor = static_cast<Monitor*>(data);
     check(monitor);
     check(monitor->getPlatformHandle() == output);
@@ -315,6 +321,8 @@ void LinuxPlatformImpl::wl_OutputHandleGeometry(void* data, struct wl_output* ou
 }
 
 void LinuxPlatformImpl::wl_OutputHandleMode(void* data, struct wl_output* output, uint32_t flags, int32_t width, int32_t height, int32_t refresh) {
+    DIRK_UNUSED(flags);
+
     auto* monitor = static_cast<Monitor*>(data);
     check(monitor);
     check(monitor->getPlatformHandle() == output);
@@ -351,6 +359,8 @@ void LinuxPlatformImpl::wl_OutputHandleDescription(void* data, struct wl_output*
 }
 
 void LinuxPlatformImpl::wl_PointerEnter(void* data, wl_pointer* pointer, uint32_t serial, wl_surface* surface, wl_fixed_t x, wl_fixed_t y) {
+    DIRK_UNUSED(serial);
+
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
     check(platform->pointer == pointer);
     auto* viewport = ImGui::FindViewportByPlatformHandle(surface);
@@ -365,6 +375,8 @@ void LinuxPlatformImpl::wl_PointerEnter(void* data, wl_pointer* pointer, uint32_
 }
 
 void LinuxPlatformImpl::wl_PointerLeave(void* data, wl_pointer* pointer, uint32_t serial, wl_surface* surface) {
+    DIRK_UNUSED(serial);
+
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
     check(platform->pointer == pointer);
     auto viewport = ImGui::FindViewportByPlatformHandle(surface);
@@ -375,6 +387,8 @@ void LinuxPlatformImpl::wl_PointerLeave(void* data, wl_pointer* pointer, uint32_
 }
 
 void LinuxPlatformImpl::wl_PointerMotion(void* data, wl_pointer* pointer, uint32_t time, wl_fixed_t x, wl_fixed_t y) {
+    DIRK_UNUSED(time);
+
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
     check(platform->pointer == pointer);
     auto viewport = ImGui::FindViewportByPlatformHandle(platform->pointerSurface);
@@ -398,6 +412,8 @@ void LinuxPlatformImpl::wl_PointerMotion(void* data, wl_pointer* pointer, uint32
 }
 
 void LinuxPlatformImpl::wl_PointerButton(void* data, wl_pointer* pointer, uint32_t serial, uint32_t time, uint32_t inButton, uint32_t inState) {
+    DIRK_UNUSED(time);
+
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
     check(platform->pointer == pointer);
     auto viewport = ImGui::FindViewportByPlatformHandle(platform->pointerSurface);
@@ -415,6 +431,8 @@ void LinuxPlatformImpl::wl_PointerButton(void* data, wl_pointer* pointer, uint32
 }
 
 void LinuxPlatformImpl::wl_PointerAxis(void* data, wl_pointer* pointer, uint32_t time, uint32_t axis, wl_fixed_t value) {
+    DIRK_UNUSED(time);
+
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
     check(platform->pointer == pointer);
     auto viewport = ImGui::FindViewportByPlatformHandle(platform->pointerSurface);
@@ -430,6 +448,7 @@ void LinuxPlatformImpl::wl_PointerAxis(void* data, wl_pointer* pointer, uint32_t
 
 void LinuxPlatformImpl::wl_KeyboardKeymap(void* data, wl_keyboard* keyboard, uint32_t format, int32_t fd, uint32_t size) {
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
+    check(platform->keyboard == keyboard);
 
     check(format == WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1);
     char* keymapStr = static_cast<char*>(mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0));
@@ -451,6 +470,8 @@ void LinuxPlatformImpl::wl_KeyboardKeymap(void* data, wl_keyboard* keyboard, uin
 }
 
 void LinuxPlatformImpl::wl_KeyboardEnter(void* data, wl_keyboard* keyboard, uint32_t serial, wl_surface* surface, wl_array* keys) {
+    DIRK_UNUSED(keys);
+
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
     check(platform->keyboard == keyboard);
     auto viewport = ImGui::FindViewportByPlatformHandle(surface);
@@ -463,6 +484,8 @@ void LinuxPlatformImpl::wl_KeyboardEnter(void* data, wl_keyboard* keyboard, uint
 }
 
 void LinuxPlatformImpl::wl_KeyboardLeave(void* data, wl_keyboard* keyboard, uint32_t serial, wl_surface* surface) {
+    DIRK_UNUSED(serial);
+
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
     check(platform->keyboard == keyboard);
     auto viewport = ImGui::FindViewportByPlatformHandle(surface);
@@ -474,6 +497,9 @@ void LinuxPlatformImpl::wl_KeyboardLeave(void* data, wl_keyboard* keyboard, uint
 }
 
 void LinuxPlatformImpl::wl_KeyboardKey(void* data, wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t inKey, uint32_t inState) {
+    DIRK_UNUSED(serial);
+    DIRK_UNUSED(time);
+
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
     check(platform->keyboard == keyboard);
     check(platform->xkbState);
@@ -498,6 +524,8 @@ void LinuxPlatformImpl::wl_KeyboardKey(void* data, wl_keyboard* keyboard, uint32
 }
 
 void LinuxPlatformImpl::wl_KeyboardModifiers(void* data, wl_keyboard* keyboard, uint32_t serial, uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group) {
+    DIRK_UNUSED(serial);
+
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
     check(platform->keyboard == keyboard);
     check(platform->xkbState);
@@ -506,6 +534,7 @@ void LinuxPlatformImpl::wl_KeyboardModifiers(void* data, wl_keyboard* keyboard, 
 
 void LinuxPlatformImpl::wl_DataDeviceOffer(void* data, wl_data_device* dataDevice, wl_data_offer* offer) {
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
+    check(platform->dataDevice == dataDevice);
 
     check(offer);
 
@@ -526,6 +555,7 @@ void LinuxPlatformImpl::wl_DataDeviceOffer(void* data, wl_data_device* dataDevic
 
 void LinuxPlatformImpl::wl_DataDeviceEnter(void* data, wl_data_device* dataDevice, uint32_t serial, wl_surface* surface, wl_fixed_t x, wl_fixed_t y, wl_data_offer* offer) {
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
+    check(platform->dataDevice == dataDevice);
 
     // Find viewport for this surface
     ImGuiViewport* enteringViewport = ImGui::FindViewportByPlatformHandle(surface);
@@ -565,11 +595,15 @@ void LinuxPlatformImpl::wl_DataDeviceEnter(void* data, wl_data_device* dataDevic
 
 void LinuxPlatformImpl::wl_DataDeviceLeave(void* data, wl_data_device* dataDevice) {
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
+    check(platform->dataDevice == dataDevice);
     platform->dragEnterSurface = nullptr;
 }
 
 void LinuxPlatformImpl::wl_DataDeviceMotion(void* data, wl_data_device* dataDevice, uint32_t time, wl_fixed_t x, wl_fixed_t y) {
+    DIRK_UNUSED(time);
+
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
+    check(platform->dataDevice == dataDevice);
 
     platform->dragCursorPos = { wl_fixed_to_double(x), wl_fixed_to_double(y) };
 
@@ -625,6 +659,7 @@ void LinuxPlatformImpl::wl_DataDeviceMotion(void* data, wl_data_device* dataDevi
 
 void LinuxPlatformImpl::wl_DataDeviceDrop(void* data, wl_data_device* dataDevice) {
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
+    check(platform->dataDevice == dataDevice);
 
     // When we receive a drop event, we need to acknowledge it by calling finish()
     // on the current data offer. This signals to the source that the drop was
@@ -637,6 +672,9 @@ void LinuxPlatformImpl::wl_DataDeviceDrop(void* data, wl_data_device* dataDevice
 
 void LinuxPlatformImpl::wl_DataDeviceSelection(void* data, wl_data_device* dataDevice, wl_data_offer* offer) {
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
+    check(platform->dataDevice == dataDevice);
+
+    DIRK_UNUSED(offer);
 
     // TODO: clipboard support
     // Selection/clipboard offer - we don't handle clipboard, so ignore this.
@@ -664,6 +702,7 @@ void LinuxPlatformImpl::wl_DataSourceCancelled(void* data, struct wl_data_source
 
 void LinuxPlatformImpl::wl_DataSourceDndDropPerformed(void* data, struct wl_data_source* dataSource) {
     auto* platform = static_cast<LinuxPlatformImpl*>(data);
+    check(platform->activeDataSource == dataSource);
 
     // During DnD, the pointer is grabbed and button release events don't come through
     // wl_pointer - we must notify ImGui of the button release here so it can process

--- a/Engine/Source/Platform/src/platform/linux/window.cpp
+++ b/Engine/Source/Platform/src/platform/linux/window.cpp
@@ -243,6 +243,7 @@ void LinuxWindowImpl::xdg_ToplevelConfigure(void* data, xdg_toplevel* toplevel, 
 }
 
 void LinuxWindowImpl::xdg_ToplevelClose(void* data, xdg_toplevel* toplevel) {
+    DIRK_UNUSED(toplevel);
     auto* window = static_cast<LinuxWindowImpl*>(data);
     auto* viewport = ImGui::FindViewportByPlatformHandle(window->wlSurface);
     check(viewport);

--- a/Engine/Source/Platform/src/platform/platform.cpp
+++ b/Engine/Source/Platform/src/platform/platform.cpp
@@ -106,7 +106,7 @@ void Platform::initImGui() {
     platformIO.Platform_GetWindowSize = ImGui_GetWindowSize;
     platformIO.Platform_SetWindowFocus = ImGui_SetWindowFocus;
     platformIO.Platform_GetWindowFocus = ImGui_GetWindowFocus;
-    platformIO.Platform_GetWindowMinimized = [](ImGuiViewport* vp) { return false; };
+    platformIO.Platform_GetWindowMinimized = [](ImGuiViewport*) { return false; };
     platformIO.Platform_SetWindowTitle = ImGui_SetWindowTitle;
     platformIO.Platform_SetWindowAlpha = [](ImGuiViewport*, float) {};
     platformIO.Platform_CreateVkSurface = ImGui_CreateVkSurface;
@@ -125,6 +125,8 @@ void Platform::initImGui() {
 }
 
 void Platform::tick(float deltaTime) {
+    DIRK_UNUSED(deltaTime);
+
     ImGuiIO& io = ImGui::GetIO();
     ImGuiPlatformData* bd = getBackendData();
     check(bd);
@@ -194,7 +196,7 @@ void Platform::ImGui_DestroyWindow(ImGuiViewport* viewport) {
     // Release any keys that were pressed in the window being destroyed and are still held down,
     // because we will not receive any release events after window is destroyed.
     if (vd->windowOwned) {
-        for (int i = 0; i < bd->keyOwnerWindows.size(); i++)
+        for (size_t i = 0; i < bd->keyOwnerWindows.size(); i++)
             if (bd->keyOwnerWindows[i] == vd->window.get()) {
                 auto* eventManager = gEngine->getEventManager();
                 eventManager->submitEvent(std::make_unique<KeyboardKeyPlatformEvent>(viewport, (Input::Key) i, Input::KeyState::Released));
@@ -234,7 +236,6 @@ ImVec2 Platform::ImGui_GetWindowSize(ImGuiViewport* viewport) {
 }
 
 void Platform::ImGui_SetWindowFocus(ImGuiViewport* viewport) {
-    ImGuiPlatformData* bd = getBackendData();
     ImGuiViewportPlatformData* vd = (ImGuiViewportPlatformData*) viewport->PlatformUserData;
     vd->window->focus();
 }

--- a/Engine/Source/Runtime/include/engine/actor.hpp
+++ b/Engine/Source/Runtime/include/engine/actor.hpp
@@ -36,10 +36,6 @@ public:
     inline void setVisibity(bool inVisible) { visible = inVisible; }
     inline bool isVisible() { return visible; }
 
-private:
-    std::string_view name;
-    bool visible = false;
-
 public:
     inline const Transform& getTransform() const { return transform; }
     inline void setTransform(const Transform& inTransform);
@@ -73,6 +69,9 @@ private:
     std::shared_ptr<const Model> model;
     // owned by world
     World& world;
+
+    std::string_view name;
+    bool visible = false;
 
     vk::DescriptorSet descriptorSet;
 

--- a/Engine/Source/Runtime/include/render/camera.hpp
+++ b/Engine/Source/Runtime/include/render/camera.hpp
@@ -44,21 +44,20 @@ private:
     glm::mat4 view{ 1.f };
     glm::mat4 inverseView{ 1.f };
 
+    // camera is owned by the viewport
+    Viewport& viewport;
+
     // camera settings
+    vk::Extent2D size;
+    glm::vec3 position{ 0.f };
+    glm::vec3 forwardDirection{ 0.f };
+
     float fov = glm::radians(45.f);
     float nearClip = .1f;
     float farClip = 100.f;
 
-    glm::vec3 position{ 0.f };
-    glm::vec3 forwardDirection{ 0.f };
-
-    glm::vec2 lastMousePosition{ 0.f };
-    vk::Extent2D size;
-
-    // camera is owned by the viewport
-    Viewport& viewport;
-
     // state
+    glm::vec2 lastMousePosition{ 0.f };
     glm::vec3 cachedMoveInput = { 0.f, 0.f, 0.f };
     glm::vec2 cachedLookInput = { 0.f, 0.f };
 

--- a/Engine/Source/Runtime/src/engine/actor.cpp
+++ b/Engine/Source/Runtime/src/engine/actor.cpp
@@ -1,10 +1,10 @@
 #include "engine/actor.hpp"
 
+#include "core.hpp"
 #include "engine/dirkengine.hpp"
 #include "engine/world.hpp"
 #include "render/camera.hpp"
 #include "render/render_types.hpp"
-#include "render/renderer.hpp"
 
 #include "resources/resource_manager.hpp"
 #include "vulkan/vulkan_enums.hpp"
@@ -16,10 +16,10 @@
 namespace dirk {
 
 Actor::Actor(const ActorCreateInfo& spawnInfo, World& world)
-    : world(world),
-      name(spawnInfo.name),
-      transform(spawnInfo.transform),
-      transformMatrix(transform.getMatrix()) {
+    : transform(spawnInfo.transform),
+      transformMatrix(transform.getMatrix()),
+      world(world),
+      name(spawnInfo.name) {
     setModel(spawnInfo.modelName);
 }
 
@@ -28,7 +28,9 @@ void Actor::setModel(const std::string_view name) {
     updateData();
 }
 
-void Actor::tick(float deltaTime) {}
+void Actor::tick(float deltaTime) {
+    DIRK_UNUSED(deltaTime);
+}
 
 void Actor::destroy() {
     getWorld().destroyActor(this);

--- a/Engine/Source/Runtime/src/render/camera.cpp
+++ b/Engine/Source/Runtime/src/render/camera.cpp
@@ -1,13 +1,8 @@
 #include "render/camera.hpp"
 
-#include "glm/gtc/matrix_transform.hpp"
-#include "glm/gtc/quaternion.hpp"
-#include "glm/gtx/hash.hpp"
 #include "glm/gtx/quaternion.hpp"
 #include "render/renderer.hpp"
 #include "vulkan/vulkan_structs.hpp"
-
-#include <cstdint>
 
 namespace dirk {
 

--- a/Engine/Source/Runtime/src/render/renderer.cpp
+++ b/Engine/Source/Runtime/src/render/renderer.cpp
@@ -153,7 +153,7 @@ void Renderer::init(vk::SurfaceKHR surface) {
         std::set<uint32_t> uniqueQueueFamilies = { properties.queueFamilyIndices.graphicsFamily.value(), properties.queueFamilyIndices.presentFamily.value() };
         std::vector<vk::DeviceQueueCreateInfo> queueCreateInfos(uniqueQueueFamilies.size());
         float queuePriority = 1.f;
-        for (int i = 0; i < uniqueQueueFamilies.size(); i++) {
+        for (size_t i = 0; i < uniqueQueueFamilies.size(); i++) {
             std::set<uint32_t>::iterator iter = uniqueQueueFamilies.find(i);
             if (iter == uniqueQueueFamilies.end()) {
                 DIRK_LOG(LogVulkan, FATAL, "error creating logical device");
@@ -354,7 +354,7 @@ std::vector<SwapchainImage> Renderer::createSwapChain(const SwapChainCreateInfo&
 
     std::vector<SwapchainImage> swapImages(images.size());
 
-    for (int i = 0; i < images.size(); i++) {
+    for (size_t i = 0; i < images.size(); i++) {
         auto commandBuffer = beginSingleTimeCommands();
         transitionImageLayout(commandBuffer, images[i], createInfo.surfaceFormat.format, vk::ImageLayout::eUndefined, vk::ImageLayout::ePresentSrcKHR);
         endSingleTimeCommands(commandBuffer, queues.graphicsQueue);
@@ -533,6 +533,8 @@ vk::Bool32 Renderer::debugCallback(
     vk::DebugUtilsMessageTypeFlagsEXT messageType,
     const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData,
     void* pUserData) {
+    DIRK_UNUSED(messageType);
+    DIRK_UNUSED(pUserData);
 
     switch (messageSeverity) {
     case vk::DebugUtilsMessageSeverityFlagBitsEXT::eError:
@@ -986,7 +988,7 @@ void Renderer::ImGui_renderWindow(ImGuiViewport* viewport) {
         vd->swapChainImages = createSwapChain(swapChainInfo);
 
         vd->semaphores.resize(vd->swapChainImages.size());
-        for (int i = 0; i < vd->semaphores.size(); i++) {
+        for (size_t i = 0; i < vd->semaphores.size(); i++) {
             vd->semaphores[i] = std::tuple(createSemaphore(), createSemaphore());
         }
 

--- a/Engine/Source/Runtime/src/render/viewport.cpp
+++ b/Engine/Source/Runtime/src/render/viewport.cpp
@@ -24,7 +24,7 @@ namespace dirk {
 DEFINE_LOG_CATEGORY(LogViewport);
 
 Viewport::Viewport(const ViewportCreateInfo& createInfo)
-    : world(createInfo.world), size(createInfo.size), name(createInfo.name) {
+    : name(createInfo.name), size(createInfo.size), world(createInfo.world) {
     camera = std::make_unique<Camera>(
         CameraCreateInfo{
             .positon = { 0.f, 1000.f, 1000.f },
@@ -40,7 +40,6 @@ Viewport::Viewport(const ViewportCreateInfo& createInfo)
 
     auto renderer = gEngine->getRenderer();
     auto resources = renderer->getResources();
-    auto properties = renderer->getProperties();
     renderFinishedSemaphore = renderer->createSemaphore();
 
     // COMMAND BUFFER
@@ -257,7 +256,6 @@ void Viewport::cleanupRenderResources() {
 }
 
 vk::SubmitInfo Viewport::render() {
-    auto properties = gEngine->getRenderer()->getProperties();
     commandBuffer.reset();
 
     vk::CommandBufferBeginInfo beginInfo{};


### PR DESCRIPTION
## Summary of the PR

There are no long any build warnings that come from the project. Only thridparty.

## Issues linked to the PR: Closes #96 

## Changes

- Add warning flags to compile commands
- Add default config for CLI
- Add `DIRK_UNUSED` macro for unused function parameters
- Went through files to fix warnings:
  - Initializer list order
  - No initializer for member
  - unused variable
  - unused parameter
  - change iterator types in some loops
- Added some assertions that can come in handy